### PR TITLE
Add cli overrides 

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ yes
   - [ ] Unofficial packaging
 - Package formats
   - [x] Tgz
+  - [x] TarGz
   - [x] Txz
   - [x] Tar
   - [x] Zip
@@ -107,7 +108,7 @@ Template variables use the format `{ VAR }` where `VAR` is the name of the varia
 
 `pkg-url`, `pkg-fmt` and `bin-path` can be overridden on a per-target basis if required, for example, if your `x86_64-pc-windows-msvc` builds use `zip` archives this could be set via:
 
-```
+```toml
 [package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
 pkg-fmt = "zip"
 ```
@@ -157,6 +158,23 @@ bin-dir = "{ bin }-{ target }{ format }"
 ```
 
 Which provides a binary path of: `sx128x-util-x86_64-unknown-linux-gnu[.exe]`. It is worth noting that binary names are inferred from the crate, so long as cargo builds them this _should_ just work.
+
+## Installing unsupported crates
+
+If you would like to use this tool to download crates unsupported crates, you can override the following templates at the command line:
+
+- `pkg-url` templated specification for the package download URL for a given target/version
+- `bin-path` templated specification for the binary path within the package (`.exe` suffix added automatically on windows)
+- `pkg-fmt` overrides the package format for download/extraction (defaults to: `tgz`)
+
+These values replace the template and are applied over any metadata supplied by the package. Once a package adds support, removing these overrides is best practice.
+
+### Examples
+
+This crate has no v on the version number, the version and target are switched, and uses tar.gz extension.
+```
+[garry] ➜  ~  binstall --pkg-url="{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.{ format }" --pkg-fmt="tar.gz" crate_name
+```
 
 ## FAQ
 

--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -18,7 +18,7 @@ fn find_version<'a, V: Iterator<Item=&'a str>>(requirement: &str, version_iter: 
     // Filter for matching versions
     let mut filtered: Vec<_> = version_iter.filter(|v| {
         // Remove leading `v` for git tags
-        let ver_str = match v.strip_prefix("s") {
+        let ver_str = match v.strip_prefix('s') {
             Some(v) => v,
             None => v,
         };

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -57,7 +57,7 @@ pub fn extract<S: AsRef<Path>, P: AsRef<Path>>(source: S, fmt: PkgFmt, path: P) 
 
             tar.unpack(path)?;
         },
-        PkgFmt::Tgz => {
+        PkgFmt::Tgz | PkgFmt::TarGz => {
             // Extract to install dir
             debug!("Decompressing from tgz archive '{:?}' to `{:?}`", source.as_ref(), path.as_ref());
 
@@ -129,7 +129,7 @@ pub fn get_install_path<P: AsRef<Path>>(install_path: Option<P>) -> Option<PathB
     // Local executable dir if no cargo is found
     if let Some(d) = dirs::executable_dir() {
         debug!("Fallback to {}", d.display());
-        return Some(d.into());
+        return Some(d);
     }
 
     None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,13 +14,13 @@ pub use drivers::*;
 
 
 /// Compiled target triple, used as default for binary fetching
-pub const TARGET: &'static str = env!("TARGET");
+pub const TARGET: &str = env!("TARGET");
 
 /// Default package path template (may be overridden in package Cargo.toml)
-pub const DEFAULT_PKG_URL: &'static str = "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ format }";
+pub const DEFAULT_PKG_URL: &str = "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ format }";
 
 /// Default binary name template (may be overridden in package Cargo.toml)
-pub const DEFAULT_BIN_PATH: &'static str = "{ name }-{ target }-v{ version }/{ bin }{ format }";
+pub const DEFAULT_BIN_PATH: &str = "{ name }-{ target }-v{ version }/{ bin }{ format }";
 
 
 /// Binary format enumeration
@@ -33,6 +33,9 @@ pub enum PkgFmt {
     Tar,
     /// Download format is TGZ (TAR + GZip)
     Tgz,
+    /// Download format is TAR.GZ (TAR + GZip)
+    #[strum(serialize = "tar.gz")]
+    TarGz,
     /// Download format is TAR + XZ
     Txz,
     /// Download format is Zip
@@ -159,7 +162,7 @@ impl Context {
         let mut tt = TinyTemplate::new();
 
         // Add template to instance
-        tt.add_template("path", &template)?;
+        tt.add_template("path", template)?;
 
         // Render output
         let rendered = tt.render("path", self)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let cli_overrides = PkgOverride {
         pkg_url: opts.pkg_url.clone(),
         pkg_fmt: opts.pkg_fmt,
-        bin_dir: opts.bin_dir.clone(),
+        bin_dir: opts.bin_path.clone(),
     };
 
     // Setup logging

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ struct Options {
 
     /// Override Cargo.toml package manifest bin-dir.
     #[structopt(long)]
-    bin_dir: Option<String>,
+    bin_path: Option<String>,
 }
 
 


### PR DESCRIPTION
fixes #69 

This adds support for overriding `pkg-url`, `bin-path`, and `pkg-format` using cli arguments of the same name.

For example, to install Just, which doesn't follow the standard format:

```
cargo binstall --pkg-url="{ repo }/releases/download/{ version }/{ name }-{ version }-{ target }.{ format }" --pkg-fmt="tar.gz" --bin-path="{name}" --target=x86_64-unknown-linux-musl just
```

I also applied a couple of clippy recommendations and added support for tar.gz