### PR TITLE
Fix the package metadata test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ mod test {
 
         assert_eq!(
             &meta.pkg_url,
-            "{ repo }/releases/download/v{ version }/{ name }-{ target }.tgz"
+            "{ repo }/releases/download/v{ version }/{ name }-{ target }.{ format }"
         );
 
         assert_eq!(


### PR DESCRIPTION
This PR fixes the `parse_meta` test which was failing due to outdated/wrong metadata:

```
running 1 test
test test::parse_meta ... FAILED

failures:

---- test::parse_meta stdout ----
thread 'test::parse_meta' panicked at 'assertion failed: `(left == right)`
  left: `"{ repo }/releases/download/v{ version }/{ name }-{ target }.{ format }"`,
 right: `"{ repo }/releases/download/v{ version }/{ name }-{ target }.tgz"`', src/lib.rs:194:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    test::parse_meta

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

error: test failed, to rerun pass '--lib'
```

References:

https://github.com/ryankurte/cargo-binstall/blob/8b4e77918c0b1efaad01298eb995570e2c01075c/Cargo.toml#L13

https://github.com/ryankurte/cargo-binstall/blob/8b4e77918c0b1efaad01298eb995570e2c01075c/src/lib.rs#L194-L197

