### PR TITLE
QuickInstall support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
  "tempdir",
  "tinytemplate",
  "tokio",
+ "url",
  "xz2",
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b26702f315f53b6071259e15dd9d64528213b44d61de1ec926eca7715d62203"
 
 [[package]]
+name = "async-trait"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061a7acccaa286c011ddc30970520b98fa40e00c9d644633fb26b5fc63a265e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +125,7 @@ name = "cargo-binstall"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "cargo_metadata",
  "cargo_toml",
  "crates-index",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ semver = "1.0.4"
 xz2 = "0.1.6"
 zip = "0.5.13"
 async-trait = "0.1.52"
+url = "2.2.2"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ crates-index = "0.18.1"
 semver = "1.0.4"
 xz2 = "0.1.6"
 zip = "0.5.13"
+async-trait = "0.1.52"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ yes
   - [x] Fetch crate / manifest via crates.io
   - [ ] Fetch crate / manifest via git (/ github / gitlab)
   - [x] Use local crate / manifest (`--manifest-path`)
+  - [x] Fetch build from the [quickinstall](https://github.com/alsuren/cargo-quickinstall) repository
   - [ ] Unofficial packaging
 - Package formats
   - [x] Tgz
@@ -126,6 +127,10 @@ By default `binstall` is setup to work with github releases, and expects to find
 
 If your package already uses this approach, you shouldn't need to set anything.
 
+### QuickInstall
+
+[QuickInstall](https://github.com/alsuren/cargo-quickinstall) is an unofficial repository of prebuilt binaries for Crates, and `binstall` has built-in support for it! If your crate is built by QuickInstall, it will already work with `binstall`. However, binaries as configured above take precedence when they exist.
+
 ### Examples
 
 For example, the default configuration (as shown above) for a crate called `radio-sx128x` (version: `v0.14.1-alpha.5` on x86_64 linux) would be interpolated to:
@@ -166,9 +171,6 @@ Which provides a binary path of: `sx128x-util-x86_64-unknown-linux-gnu[.exe]`. I
 - Why use the cargo manifest?
   - Crates already have these, and they already contain a significant portion of the required information.
     Also there's this great and woefully underused (imo) `[package.metadata]` field.
-- Why not use a binary repository instead?
-  - Then we'd need to _host_ a binary repository, and worry about publishing and all the other fun things that come with releasing software.
-    This way we can use existing CI infrastructure and build artifacts, and maintainers can choose how to distribute their packages.
 - Is this secure?
   - Yes and also no? We're not (yet? #1) doing anything to verify the CI binaries are produced by the right person / organisation.
     However, we're pulling data from crates.io and the cargo manifest, both of which are _already_ trusted entities, and this is

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,3 @@
-
 // Fetch build target and define this for the compiler
 fn main() {
     println!(

--- a/src/bins.rs
+++ b/src/bins.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use cargo_toml::Product;
 use serde::Serialize;
 
-use crate::{Template, PkgFmt, PkgMeta};
+use crate::{PkgFmt, PkgMeta, Template};
 
 pub struct BinFile {
     pub base_name: String,
@@ -17,12 +17,16 @@ impl BinFile {
         let base_name = product.name.clone().unwrap();
 
         // Generate binary path via interpolation
-        let ctx = Context { 
+        let ctx = Context {
             name: &data.name,
             repo: data.repo.as_ref().map(|s| &s[..]),
-            target: &data.target, 
+            target: &data.target,
             version: &data.version,
-            format: if data.target.contains("windows") { ".exe" } else { "" },
+            format: if data.target.contains("windows") {
+                ".exe"
+            } else {
+                ""
+            },
             bin: &base_name,
         };
 
@@ -36,21 +40,36 @@ impl BinFile {
         };
 
         // Destination path is the install dir + base-name-version{.format}
-        let dest_file_path = ctx.render("{ bin }-v{ version }{ format }")?; 
+        let dest_file_path = ctx.render("{ bin }-v{ version }{ format }")?;
         let dest = data.install_path.join(dest_file_path);
 
         // Link at install dir + base name
         let link = data.install_path.join(&base_name);
 
-        Ok(Self { base_name, source, dest, link })
+        Ok(Self {
+            base_name,
+            source,
+            dest,
+            link,
+        })
     }
 
     pub fn preview_bin(&self) -> String {
-        format!("{} ({} -> {})", self.base_name, self.source.file_name().unwrap().to_string_lossy(), self.dest.display())
+        format!(
+            "{} ({} -> {})",
+            self.base_name,
+            self.source.file_name().unwrap().to_string_lossy(),
+            self.dest.display()
+        )
     }
 
     pub fn preview_link(&self) -> String {
-        format!("{} ({} -> {})", self.base_name, self.dest.display(), self.link.display())
+        format!(
+            "{} ({} -> {})",
+            self.base_name,
+            self.dest.display(),
+            self.link.display()
+        )
     }
 
     pub fn install_bin(&self) -> Result<(), anyhow::Error> {

--- a/src/bins.rs
+++ b/src/bins.rs
@@ -1,0 +1,106 @@
+use std::path::PathBuf;
+
+use cargo_toml::Product;
+use serde::Serialize;
+
+use crate::{Template, PkgFmt, PkgMeta};
+
+pub struct BinFile {
+    pub base_name: String,
+    pub source: PathBuf,
+    pub dest: PathBuf,
+    pub link: PathBuf,
+}
+
+impl BinFile {
+    pub fn from_product(data: &Data, product: &Product) -> Result<Self, anyhow::Error> {
+        let base_name = product.name.clone().unwrap();
+
+        // Generate binary path via interpolation
+        let ctx = Context { 
+            name: &data.name,
+            repo: data.repo.as_ref().map(|s| &s[..]),
+            target: &data.target, 
+            version: &data.version,
+            format: if data.target.contains("windows") { ".exe" } else { "" },
+            bin: &base_name,
+        };
+
+        // Generate install paths
+        // Source path is the download dir + the generated binary path
+        let source_file_path = ctx.render(&data.meta.bin_dir)?;
+        let source = if data.meta.pkg_fmt == PkgFmt::Bin {
+            data.bin_path.clone()
+        } else {
+            data.bin_path.join(&source_file_path)
+        };
+
+        // Destination path is the install dir + base-name-version{.format}
+        let dest_file_path = ctx.render("{ bin }-v{ version }{ format }")?; 
+        let dest = data.install_path.join(dest_file_path);
+
+        // Link at install dir + base name
+        let link = data.install_path.join(&base_name);
+
+        Ok(Self { base_name, source, dest, link })
+    }
+
+    pub fn preview_bin(&self) -> String {
+        format!("{} ({} -> {})", self.base_name, self.source.file_name().unwrap().to_string_lossy(), self.dest.display())
+    }
+
+    pub fn preview_link(&self) -> String {
+        format!("{} ({} -> {})", self.base_name, self.dest.display(), self.link.display())
+    }
+
+    pub fn install_bin(&self) -> Result<(), anyhow::Error> {
+        // TODO: check if file already exists
+        std::fs::copy(&self.source, &self.dest)?;
+
+        #[cfg(target_family = "unix")]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&self.dest, std::fs::Permissions::from_mode(0o755))?;
+        }
+
+        Ok(())
+    }
+
+    pub fn install_link(&self) -> Result<(), anyhow::Error> {
+        // Remove existing symlink
+        // TODO: check if existing symlink is correct
+        if self.link.exists() {
+            std::fs::remove_file(&self.link)?;
+        }
+
+        #[cfg(target_family = "unix")]
+        std::os::unix::fs::symlink(&self.dest, &self.link)?;
+        #[cfg(target_family = "windows")]
+        std::os::windows::fs::symlink_file(&self.dest, &self.link)?;
+
+        Ok(())
+    }
+}
+
+/// Data required to get bin paths
+pub struct Data {
+    pub name: String,
+    pub target: String,
+    pub version: String,
+    pub repo: Option<String>,
+    pub meta: PkgMeta,
+    pub bin_path: PathBuf,
+    pub install_path: PathBuf,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct Context<'c> {
+    pub name: &'c str,
+    pub repo: Option<&'c str>,
+    pub target: &'c str,
+    pub version: &'c str,
+    pub format: &'c str,
+    pub bin: &'c str,
+}
+
+impl<'c> Template for Context<'c> {}

--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -1,39 +1,43 @@
-
-use std::time::Duration;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-use log::{debug};
-use anyhow::{Context, anyhow};
+use anyhow::{anyhow, Context};
+use log::debug;
 use semver::{Version, VersionReq};
 
 use crates_io_api::AsyncClient;
 
-use crate::PkgFmt;
 use crate::helpers::*;
+use crate::PkgFmt;
 
-fn find_version<'a, V: Iterator<Item=&'a str>>(requirement: &str, version_iter: V) -> Result<String, anyhow::Error> {
+fn find_version<'a, V: Iterator<Item = &'a str>>(
+    requirement: &str,
+    version_iter: V,
+) -> Result<String, anyhow::Error> {
     // Parse version requirement
     let version_req = VersionReq::parse(requirement)?;
 
     // Filter for matching versions
-    let mut filtered: Vec<_> = version_iter.filter(|v| {
-        // Remove leading `v` for git tags
-        let ver_str = match v.strip_prefix("s") {
-            Some(v) => v,
-            None => v,
-        };
+    let mut filtered: Vec<_> = version_iter
+        .filter(|v| {
+            // Remove leading `v` for git tags
+            let ver_str = match v.strip_prefix("s") {
+                Some(v) => v,
+                None => v,
+            };
 
-        // Parse out version
-        let ver = match Version::parse(ver_str) {
-            Ok(sv) => sv,
-            Err(_) => return false,
-        };
+            // Parse out version
+            let ver = match Version::parse(ver_str) {
+                Ok(sv) => sv,
+                Err(_) => return false,
+            };
 
-        debug!("Version: {:?}", ver);
+            debug!("Version: {:?}", ver);
 
-        // Filter by version match
-        version_req.matches(&ver)
-    }).collect();
+            // Filter by version match
+            version_req.matches(&ver)
+        })
+        .collect();
 
     // Sort by highest matching version
     filtered.sort_by(|a, b| {
@@ -48,13 +52,19 @@ fn find_version<'a, V: Iterator<Item=&'a str>>(requirement: &str, version_iter: 
     // Return highest version
     match filtered.get(0) {
         Some(v) => Ok(v.to_string()),
-        None => Err(anyhow!("No matching version for requirement: '{}'", version_req))
+        None => Err(anyhow!(
+            "No matching version for requirement: '{}'",
+            version_req
+        )),
     }
 }
 
 /// Fetch a crate by name and version from crates.io
-pub async fn fetch_crate_cratesio(name: &str, version_req: &str, temp_dir: &Path) -> Result<PathBuf, anyhow::Error> {
-
+pub async fn fetch_crate_cratesio(
+    name: &str,
+    version_req: &str,
+    temp_dir: &Path,
+) -> Result<PathBuf, anyhow::Error> {
     // Fetch / update index
     debug!("Updating crates.io index");
     let mut index = crates_index::Index::new_cargo_default()?;
@@ -65,37 +75,48 @@ pub async fn fetch_crate_cratesio(name: &str, version_req: &str, temp_dir: &Path
     let base_info = match index.crate_(name) {
         Some(i) => i,
         None => {
-            return Err(anyhow::anyhow!("Error fetching information for crate {}", name));
+            return Err(anyhow::anyhow!(
+                "Error fetching information for crate {}",
+                name
+            ));
         }
     };
 
     // Locate matching version
-    let version_iter = base_info.versions().iter().map(|v| v.version() );
+    let version_iter = base_info.versions().iter().map(|v| v.version());
     let version_name = find_version(version_req, version_iter)?;
-    
+
     // Build crates.io api client
-    let api_client = AsyncClient::new("cargo-binstall (https://github.com/ryankurte/cargo-binstall)", Duration::from_millis(100))?;
+    let api_client = AsyncClient::new(
+        "cargo-binstall (https://github.com/ryankurte/cargo-binstall)",
+        Duration::from_millis(100),
+    )?;
 
     // Fetch online crate information
-    let crate_info = api_client.get_crate(name.as_ref()).await
+    let crate_info = api_client
+        .get_crate(name.as_ref())
+        .await
         .context("Error fetching crate information")?;
 
     // Fetch information for the filtered version
     let version = match crate_info.versions.iter().find(|v| v.num == version_name) {
         Some(v) => v,
         None => {
-            return Err(anyhow::anyhow!("No information found for crate: '{}' version: '{}'", 
-                    name, version_name));
+            return Err(anyhow::anyhow!(
+                "No information found for crate: '{}' version: '{}'",
+                name,
+                version_name
+            ));
         }
     };
 
     debug!("Found information for crate version: '{}'", version.num);
-    
+
     // Download crate to temporary dir (crates.io or git?)
     let crate_url = format!("https://crates.io/{}", version.dl_path);
     let tgz_path = temp_dir.join(format!("{}.tgz", name));
 
-    debug!("Fetching crate from: {}", crate_url);    
+    debug!("Fetching crate from: {}", crate_url);
 
     // Download crate
     download(&crate_url, &tgz_path).await?;
@@ -111,8 +132,10 @@ pub async fn fetch_crate_cratesio(name: &str, version_req: &str, temp_dir: &Path
 
 /// Fetch a crate by name and version from github
 /// TODO: implement this
-pub async fn fetch_crate_gh_releases(_name: &str, _version: Option<&str>, _temp_dir: &Path) -> Result<PathBuf, anyhow::Error> {
-
+pub async fn fetch_crate_gh_releases(
+    _name: &str,
+    _version: Option<&str>,
+    _temp_dir: &Path,
+) -> Result<PathBuf, anyhow::Error> {
     unimplemented!();
 }
-

--- a/src/fetchers.rs
+++ b/src/fetchers.rs
@@ -1,0 +1,30 @@
+use std::path::Path;
+
+pub use gh_release::*;
+
+use crate::PkgMeta;
+
+mod gh_release;
+
+#[async_trait::async_trait]
+pub trait Fetcher {
+    /// Create a new fetcher from some data
+    async fn new(data: &Data) -> Result<Self, anyhow::Error>
+    where
+        Self: std::marker::Sized;
+
+    /// Fetch a package
+    async fn fetch(&self, dst: &Path) -> Result<(), anyhow::Error>;
+    
+    /// Check if a package is available for download
+    async fn check(&self) -> Result<bool, anyhow::Error>;
+}
+
+/// Data required to fetch a package
+pub struct Data {
+    pub name: String,
+    pub target: String,
+    pub version: String,
+    pub repo: Option<String>,
+    pub meta: PkgMeta,
+}

--- a/src/fetchers.rs
+++ b/src/fetchers.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 pub use gh_release::*;
 pub use quickinstall::*;
 
-use crate::PkgMeta;
+use crate::{PkgFmt, PkgMeta};
 
 mod gh_release;
 mod quickinstall;
@@ -20,6 +20,9 @@ pub trait Fetcher {
 
     /// Check if a package is available for download
     async fn check(&self) -> Result<bool, anyhow::Error>;
+
+    /// Return the package format
+    fn pkg_fmt(&self) -> PkgFmt;
 }
 
 /// Data required to fetch a package

--- a/src/fetchers.rs
+++ b/src/fetchers.rs
@@ -23,6 +23,12 @@ pub trait Fetcher {
 
     /// Return the package format
     fn pkg_fmt(&self) -> PkgFmt;
+
+    /// A short human-readable name or descriptor for the package source
+    fn source_name(&self) -> String;
+
+    /// Should return true if the remote is from a third-party source
+    fn is_third_party(&self) -> bool;
 }
 
 /// Data required to fetch a package

--- a/src/fetchers.rs
+++ b/src/fetchers.rs
@@ -1,11 +1,11 @@
 use std::path::Path;
 
-pub use gh_release::*;
+pub use gh_crate_meta::*;
 pub use quickinstall::*;
 
 use crate::{PkgFmt, PkgMeta};
 
-mod gh_release;
+mod gh_crate_meta;
 mod quickinstall;
 
 #[async_trait::async_trait]

--- a/src/fetchers.rs
+++ b/src/fetchers.rs
@@ -11,11 +11,13 @@ mod quickinstall;
 #[async_trait::async_trait]
 pub trait Fetcher {
     /// Create a new fetcher from some data
-    async fn new(data: &Data) -> Result<Box<Self>, anyhow::Error> where Self: Sized;
+    async fn new(data: &Data) -> Result<Box<Self>, anyhow::Error>
+    where
+        Self: Sized;
 
     /// Fetch a package
     async fn fetch(&self, dst: &Path) -> Result<(), anyhow::Error>;
-    
+
     /// Check if a package is available for download
     async fn check(&self) -> Result<bool, anyhow::Error>;
 }
@@ -46,7 +48,7 @@ impl MultiFetcher {
                 return Some(&**fetcher);
             }
         }
-        
+
         None
     }
 }

--- a/src/fetchers.rs
+++ b/src/fetchers.rs
@@ -1,17 +1,17 @@
 use std::path::Path;
 
 pub use gh_release::*;
+pub use quickinstall::*;
 
 use crate::PkgMeta;
 
 mod gh_release;
+mod quickinstall;
 
 #[async_trait::async_trait]
 pub trait Fetcher {
     /// Create a new fetcher from some data
-    async fn new(data: &Data) -> Result<Self, anyhow::Error>
-    where
-        Self: std::marker::Sized;
+    async fn new(data: &Data) -> Result<Box<Self>, anyhow::Error> where Self: Sized;
 
     /// Fetch a package
     async fn fetch(&self, dst: &Path) -> Result<(), anyhow::Error>;
@@ -21,10 +21,32 @@ pub trait Fetcher {
 }
 
 /// Data required to fetch a package
+#[derive(Debug)]
 pub struct Data {
     pub name: String,
     pub target: String,
     pub version: String,
     pub repo: Option<String>,
     pub meta: PkgMeta,
+}
+
+#[derive(Default)]
+pub struct MultiFetcher {
+    fetchers: Vec<Box<dyn Fetcher>>,
+}
+
+impl MultiFetcher {
+    pub fn add(&mut self, fetcher: Box<dyn Fetcher>) {
+        self.fetchers.push(fetcher);
+    }
+
+    pub async fn first_available(&self) -> Option<&dyn Fetcher> {
+        for fetcher in &self.fetchers {
+            if fetcher.check().await.unwrap_or(false) {
+                return Some(&**fetcher);
+            }
+        }
+        
+        None
+    }
 }

--- a/src/fetchers/gh_crate_meta.rs
+++ b/src/fetchers/gh_crate_meta.rs
@@ -33,7 +33,7 @@ impl super::Fetcher for GhCrateMeta {
 
     async fn check(&self) -> Result<bool, anyhow::Error> {
         info!("Checking for package at: '{}'", self.url);
-        remote_exists(&self.url, Method::OPTIONS).await
+        remote_exists(&self.url, Method::HEAD).await
     }
 
     async fn fetch(&self, dst: &Path) -> Result<(), anyhow::Error> {

--- a/src/fetchers/gh_crate_meta.rs
+++ b/src/fetchers/gh_crate_meta.rs
@@ -7,13 +7,13 @@ use serde::Serialize;
 use super::Data;
 use crate::{download, remote_exists, PkgFmt, Template};
 
-pub struct GhRelease {
+pub struct GhCrateMeta {
     url: String,
     pkg_fmt: PkgFmt,
 }
 
 #[async_trait::async_trait]
-impl super::Fetcher for GhRelease {
+impl super::Fetcher for GhCrateMeta {
     async fn new(data: &Data) -> Result<Box<Self>, anyhow::Error> {
         // Generate context for URL interpolation
         let ctx = Context {

--- a/src/fetchers/gh_crate_meta.rs
+++ b/src/fetchers/gh_crate_meta.rs
@@ -3,12 +3,13 @@ use std::path::Path;
 use log::{debug, info};
 use reqwest::Method;
 use serde::Serialize;
+use url::Url;
 
 use super::Data;
 use crate::{download, remote_exists, PkgFmt, Template};
 
 pub struct GhCrateMeta {
-    url: String,
+    url: Url,
     pkg_fmt: PkgFmt,
 }
 
@@ -26,23 +27,37 @@ impl super::Fetcher for GhCrateMeta {
         debug!("Using context: {:?}", ctx);
 
         Ok(Box::new(Self {
-            url: ctx.render(&data.meta.pkg_url)?,
+            url: Url::parse(&ctx.render(&data.meta.pkg_url)?)?,
             pkg_fmt: data.meta.pkg_fmt,
         }))
     }
 
     async fn check(&self) -> Result<bool, anyhow::Error> {
         info!("Checking for package at: '{}'", self.url);
-        remote_exists(&self.url, Method::HEAD).await
+        remote_exists(self.url.as_str(), Method::HEAD).await
     }
 
     async fn fetch(&self, dst: &Path) -> Result<(), anyhow::Error> {
         info!("Downloading package from: '{}'", self.url);
-        download(&self.url, dst).await
+        download(self.url.as_str(), dst).await
     }
 
     fn pkg_fmt(&self) -> PkgFmt {
         self.pkg_fmt
+    }
+
+    fn source_name(&self) -> String {
+        if let Some(domain) = self.url.domain() {
+            domain.to_string()
+        } else if let Some(host) = self.url.host_str() {
+            host.to_string()
+        } else {
+            self.url.to_string()
+        }
+    }
+
+    fn is_third_party(&self) -> bool {
+        false
     }
 }
 

--- a/src/fetchers/gh_release.rs
+++ b/src/fetchers/gh_release.rs
@@ -5,10 +5,11 @@ use reqwest::Method;
 use serde::Serialize;
 
 use super::Data;
-use crate::{download, remote_exists, Template};
+use crate::{download, remote_exists, PkgFmt, Template};
 
 pub struct GhRelease {
     url: String,
+    pkg_fmt: PkgFmt,
 }
 
 #[async_trait::async_trait]
@@ -26,6 +27,7 @@ impl super::Fetcher for GhRelease {
 
         Ok(Box::new(Self {
             url: ctx.render(&data.meta.pkg_url)?,
+            pkg_fmt: data.meta.pkg_fmt,
         }))
     }
 
@@ -37,6 +39,10 @@ impl super::Fetcher for GhRelease {
     async fn fetch(&self, dst: &Path) -> Result<(), anyhow::Error> {
         info!("Downloading package from: '{}'", self.url);
         download(&self.url, dst).await
+    }
+
+    fn pkg_fmt(&self) -> PkgFmt {
+        self.pkg_fmt
     }
 }
 

--- a/src/fetchers/gh_release.rs
+++ b/src/fetchers/gh_release.rs
@@ -4,8 +4,8 @@ use log::{debug, info};
 use reqwest::Method;
 use serde::Serialize;
 
-use crate::{download, remote_exists, Template};
 use super::Data;
+use crate::{download, remote_exists, Template};
 
 pub struct GhRelease {
     url: String,
@@ -15,16 +15,18 @@ pub struct GhRelease {
 impl super::Fetcher for GhRelease {
     async fn new(data: &Data) -> Result<Box<Self>, anyhow::Error> {
         // Generate context for URL interpolation
-        let ctx = Context { 
+        let ctx = Context {
             name: &data.name,
             repo: data.repo.as_ref().map(|s| &s[..]),
-            target: &data.target, 
+            target: &data.target,
             version: &data.version,
             format: data.meta.pkg_fmt.to_string(),
         };
         debug!("Using context: {:?}", ctx);
 
-        Ok(Box::new(Self { url: ctx.render(&data.meta.pkg_url)? }))
+        Ok(Box::new(Self {
+            url: ctx.render(&data.meta.pkg_url)?,
+        }))
     }
 
     async fn check(&self) -> Result<bool, anyhow::Error> {

--- a/src/fetchers/gh_release.rs
+++ b/src/fetchers/gh_release.rs
@@ -1,0 +1,50 @@
+use std::path::Path;
+
+use log::{debug, info};
+use serde::Serialize;
+
+use crate::{download, head, Template};
+use super::Data;
+
+pub struct GhRelease {
+    url: String,
+}
+
+#[async_trait::async_trait]
+impl super::Fetcher for GhRelease {
+    async fn new(data: &Data) -> Result<Self, anyhow::Error> {
+        // Generate context for URL interpolation
+        let ctx = Context { 
+            name: &data.name,
+            repo: data.repo.as_ref().map(|s| &s[..]),
+            target: &data.target, 
+            version: &data.version,
+            format: data.meta.pkg_fmt.to_string(),
+        };
+        debug!("Using context: {:?}", ctx);
+
+        Ok(Self { url: ctx.render(&data.meta.pkg_url)? })
+    }
+
+    async fn check(&self) -> Result<bool, anyhow::Error> {
+        info!("Checking for package at: '{}'", self.url);
+        head(&self.url).await
+    }
+
+    async fn fetch(&self, dst: &Path) -> Result<(), anyhow::Error> {
+        info!("Downloading package from: '{}'", self.url);
+        download(&self.url, dst).await
+    }
+}
+
+/// Template for constructing download paths
+#[derive(Clone, Debug, Serialize)]
+struct Context<'c> {
+    pub name: &'c str,
+    pub repo: Option<&'c str>,
+    pub target: &'c str,
+    pub version: &'c str,
+    pub format: String,
+}
+
+impl<'c> Template for Context<'c> {}

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -21,7 +21,7 @@ impl super::Fetcher for QuickInstall {
 
     async fn check(&self) -> Result<bool, anyhow::Error> {
         info!("Checking for package at: '{}'", self.url);
-        remote_exists(&self.url, Method::OPTIONS).await
+        remote_exists(&self.url, Method::HEAD).await
     }
 
     async fn fetch(&self, dst: &Path) -> Result<(), anyhow::Error> {

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -8,6 +8,7 @@ use crate::{download, remote_exists, PkgFmt};
 
 const BASE_URL: &str = "https://github.com/alsuren/cargo-quickinstall/releases/download";
 const STATS_URL: &str = "https://warehouse-clerk-tmp.vercel.app/api/crate";
+const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"));
 
 pub struct QuickInstall {
     package: String,
@@ -61,7 +62,12 @@ impl QuickInstall {
 
     pub async fn report(&self) -> Result<(), anyhow::Error> {
         info!("Sending installation report to quickinstall (anonymous)");
-        remote_exists(&self.stats_url(), Method::HEAD).await?;
+        reqwest::Client::builder()
+            .user_agent(USER_AGENT)
+            .build()?
+            .request(Method::HEAD, &self.stats_url())
+            .send()
+            .await?;
         Ok(())
     }
 }

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -4,7 +4,7 @@ use log::info;
 use reqwest::Method;
 
 use super::Data;
-use crate::{download, remote_exists};
+use crate::{download, remote_exists, PkgFmt};
 
 pub struct QuickInstall {
     url: String,
@@ -27,5 +27,9 @@ impl super::Fetcher for QuickInstall {
     async fn fetch(&self, dst: &Path) -> Result<(), anyhow::Error> {
         info!("Downloading package from: '{}'", self.url);
         download(&self.url, dst).await
+    }
+
+    fn pkg_fmt(&self) -> PkgFmt {
+        PkgFmt::Tgz
     }
 }

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 use log::info;
 use reqwest::Method;
 
-use crate::{download, remote_exists};
 use super::Data;
+use crate::{download, remote_exists};
 
 pub struct QuickInstall {
     url: String,

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -41,6 +41,13 @@ impl super::Fetcher for QuickInstall {
     fn pkg_fmt(&self) -> PkgFmt {
         PkgFmt::Tgz
     }
+
+    fn source_name(&self) -> String {
+        String::from("QuickInstall")
+    }
+    fn is_third_party(&self) -> bool {
+        true
+    }
 }
 
 impl QuickInstall {

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -1,0 +1,31 @@
+use std::path::Path;
+
+use log::info;
+use reqwest::Method;
+
+use crate::{download, remote_exists};
+use super::Data;
+
+pub struct QuickInstall {
+    url: String,
+}
+
+#[async_trait::async_trait]
+impl super::Fetcher for QuickInstall {
+    async fn new(data: &Data) -> Result<Box<Self>, anyhow::Error> {
+        let crate_name = &data.name;
+        let version = &data.version;
+        let target = &data.target;
+        Ok(Box::new(Self { url: format!("https://github.com/alsuren/cargo-quickinstall/releases/download/{crate_name}-{version}-{target}/{crate_name}-{version}-{target}.tar.gz") }))
+    }
+
+    async fn check(&self) -> Result<bool, anyhow::Error> {
+        info!("Checking for package at: '{}'", self.url);
+        remote_exists(&self.url, Method::OPTIONS).await
+    }
+
+    async fn fetch(&self, dst: &Path) -> Result<(), anyhow::Error> {
+        info!("Downloading package from: '{}'", self.url);
+        download(&self.url, dst).await
+    }
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -26,8 +26,8 @@ pub fn load_manifest_path<P: AsRef<Path>>(manifest_path: P) -> Result<Manifest<M
     Ok(manifest)
 }
 
-pub async fn head(url: &str) -> Result<bool, anyhow::Error> {
-    let req = reqwest::Client::new().head(url).send().await?;
+pub async fn remote_exists(url: &str, method: reqwest::Method) -> Result<bool, anyhow::Error> {
+    let req = reqwest::Client::new().request(method, url).send().await?;
     Ok(req.status().is_success())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,14 +3,15 @@ use std::collections::HashMap;
 
 use serde::{Serialize, Deserialize};
 use strum_macros::{Display, EnumString, EnumVariantNames};
-use tinytemplate::TinyTemplate;
-
 
 pub mod helpers;
 pub use helpers::*;
 
 pub mod drivers;
 pub use drivers::*;
+
+pub mod bins;
+pub mod fetchers;
 
 
 /// Compiled target triple, used as default for binary fetching
@@ -139,33 +140,6 @@ pub struct BinMeta {
     pub name: String,
     /// Binary template path (within package)
     pub path: String,
-}
-
-/// Template for constructing download paths
-#[derive(Clone, Debug, Serialize)]
-pub struct Context {
-    pub name: String,
-    pub repo: Option<String>,
-    pub target: String,
-    pub version: String,
-    pub format: String,
-    pub bin: Option<String>,
-}
-
-impl Context {
-    /// Render the context into the provided template
-    pub fn render(&self, template: &str) -> Result<String, anyhow::Error> {
-        // Create template instance
-        let mut tt = TinyTemplate::new();
-
-        // Add template to instance
-        tt.add_template("path", &template)?;
-
-        // Render output
-        let rendered = tt.render("path", self)?;
-
-        Ok(rendered)
-    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
-
 use std::collections::HashMap;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumString, EnumVariantNames};
 
 pub mod helpers;
@@ -13,20 +12,20 @@ pub use drivers::*;
 pub mod bins;
 pub mod fetchers;
 
-
 /// Compiled target triple, used as default for binary fetching
 pub const TARGET: &'static str = env!("TARGET");
 
 /// Default package path template (may be overridden in package Cargo.toml)
-pub const DEFAULT_PKG_URL: &'static str = "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ format }";
+pub const DEFAULT_PKG_URL: &'static str =
+    "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ format }";
 
 /// Default binary name template (may be overridden in package Cargo.toml)
 pub const DEFAULT_BIN_PATH: &'static str = "{ name }-{ target }-v{ version }/{ bin }{ format }";
 
-
 /// Binary format enumeration
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
-#[derive(Display, EnumString, EnumVariantNames)]
+#[derive(
+    Debug, Copy, Clone, PartialEq, Serialize, Deserialize, Display, EnumString, EnumVariantNames,
+)]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum PkgFmt {
@@ -132,7 +131,6 @@ impl Default for PkgOverride {
     }
 }
 
-
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct BinMeta {
@@ -144,7 +142,7 @@ pub struct BinMeta {
 
 #[cfg(test)]
 mod test {
-    use crate::{load_manifest_path};
+    use crate::load_manifest_path;
 
     use cargo_toml::Product;
 
@@ -161,7 +159,7 @@ mod test {
 
         let manifest = load_manifest_path(&manifest_dir).expect("Error parsing metadata");
         let package = manifest.package.unwrap();
-        let meta = package.metadata.map(|m| m.binstall ).flatten().unwrap();
+        let meta = package.metadata.map(|m| m.binstall).flatten().unwrap();
 
         assert_eq!(&package.name, "cargo-binstall");
 
@@ -172,14 +170,12 @@ mod test {
 
         assert_eq!(
             manifest.bin.as_slice(),
-            &[
-                Product{
-                    name: Some("cargo-binstall".to_string()),
-                    path: Some("src/main.rs".to_string()),
-                    edition: Some(cargo_toml::Edition::E2018),
-                    ..Default::default()
-                },
-            ],
+            &[Product {
+                name: Some("cargo-binstall".to_string()),
+                path: Some("src/main.rs".to_string()),
+                edition: Some(cargo_toml::Edition::E2018),
+                ..Default::default()
+            },],
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,6 +151,23 @@ async fn main() -> Result<(), anyhow::Error> {
         anyhow::anyhow!("No viable remote package found")
     })?;
 
+    // Prompt user for third-party source
+    if fetcher.is_third_party() {
+        warn!(
+            "The package will be downloaded from third-party source {}",
+            fetcher.source_name()
+        );
+        if !opts.no_confirm && !confirm()? {
+            warn!("Installation cancelled");
+            return Ok(());
+        }
+    } else {
+        info!(
+            "The package will be downloaded from {}",
+            fetcher.source_name()
+        );
+    }
+
     // Download package
     fetcher.fetch(&pkg_path).await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use tempdir::TempDir;
 
 use cargo_binstall::{
     bins,
-    fetchers::{Data, Fetcher, GhRelease, MultiFetcher, QuickInstall},
+    fetchers::{Data, Fetcher, GhCrateMeta, MultiFetcher, QuickInstall},
     *,
 };
 
@@ -143,7 +143,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Try github releases, then quickinstall
     let mut fetchers = MultiFetcher::default();
-    fetchers.add(GhRelease::new(&fetcher_data).await?);
+    fetchers.add(GhCrateMeta::new(&fetcher_data).await?);
     fetchers.add(QuickInstall::new(&fetcher_data).await?);
 
     let fetcher = fetchers.first_available().await.ok_or_else(|| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     // Extract files
     let bin_path = temp_dir.path().join(format!("bin-{}", opts.name));
-    extract(&pkg_path, meta.pkg_fmt, &bin_path)?;
+    extract(&pkg_path, fetcher.pkg_fmt(), &bin_path)?;
 
     // Bypass cleanup if disabled
     if opts.no_cleanup {


### PR DESCRIPTION
See this issue: https://github.com/alsuren/cargo-quickinstall/issues/27

Quick Install is a hosted repo of built crates, essentially. The approach I've taken here is a list of strategies:
1. First, we check the crate meta or default and build the URL to the repo. Once we have that, we perform a `HEAD` request to the URL to see if it's available.
2. If it's not, we build the URL to the quickinstall repo, and perform a `HEAD` to there.

As soon as we've got a hit, we use that. I've built it so it's extensible with more strategies (e.g. for #4)