### PR TITLE
Point links to just basename-ver, print them the right way 'round

### DIFF
--- a/src/bins.rs
+++ b/src/bins.rs
@@ -1,4 +1,6 @@
 use std::path::PathBuf;
+#[cfg(target_family = "unix")]
+use std::path::Path;
 
 use cargo_toml::Product;
 use log::debug;
@@ -102,15 +104,19 @@ impl BinFile {
             std::fs::remove_file(&self.link)?;
         }
 
+        #[cfg(target_family = "unix")]
+        let dest = &Path::new(self.dest.file_name().unwrap());
+        #[cfg(target_family = "windows")]
+        let dest = &self.dest;
         debug!(
             "Create link '{}' pointing to '{}'",
             self.link.display(),
-            self.dest.display()
+            dest.display()
         );
         #[cfg(target_family = "unix")]
-        std::os::unix::fs::symlink(&self.dest, &self.link)?;
+        std::os::unix::fs::symlink(dest, &self.link)?;
         #[cfg(target_family = "windows")]
-        std::os::windows::fs::symlink_file(&self.dest, &self.link)?;
+        std::os::windows::fs::symlink_file(dest, &self.link)?;
 
         Ok(())
     }

--- a/src/bins.rs
+++ b/src/bins.rs
@@ -1,6 +1,4 @@
-use std::path::PathBuf;
-#[cfg(target_family = "unix")]
-use std::path::Path;
+use std::path::{PathBuf, Path};
 
 use cargo_toml::Product;
 use log::debug;
@@ -72,8 +70,8 @@ impl BinFile {
         format!(
             "{} ({} -> {})",
             self.base_name,
-            self.dest.display(),
-            self.link.display()
+            self.link.display(),
+            self.link_dest().display()
         )
     }
 
@@ -104,10 +102,7 @@ impl BinFile {
             std::fs::remove_file(&self.link)?;
         }
 
-        #[cfg(target_family = "unix")]
-        let dest = &Path::new(self.dest.file_name().unwrap());
-        #[cfg(target_family = "windows")]
-        let dest = &self.dest;
+        let dest = self.link_dest();
         debug!(
             "Create link '{}' pointing to '{}'",
             self.link.display(),
@@ -119,6 +114,13 @@ impl BinFile {
         std::os::windows::fs::symlink_file(dest, &self.link)?;
 
         Ok(())
+    }
+
+    fn link_dest(&self) -> &Path {
+        #[cfg(target_family = "unix")]
+        { Path::new(self.dest.file_name().unwrap()) }
+        #[cfg(target_family = "windows")]
+        { &self.dest }
     }
 }
 


### PR DESCRIPTION
I was intending to keep #103 as a draft but Ctrl-Entered by accident. Anyway, after:
```
testpsko@tarta:~/cargo-binstall$ ./target/debug/cargo-binstall binstall radio-sx128x
15:28:48 [INFO] Installing package: 'radio-sx128x'
15:28:49 [INFO] Checking for package at: 'https://github.com/rust-iot/rust-radio-sx128x/releases/download/v0.17.2/sx128x-util-x86_64-unknown-linux-gnu.tgz'
15:28:50 [INFO] The package will be downloaded from github.com
15:28:50 [INFO] Downloading package from: 'https://github.com/rust-iot/rust-radio-sx128x/releases/download/v0.17.2/sx128x-util-x86_64-unknown-linux-gnu.tgz'
15:28:52 [INFO] This will install the following binaries:
15:28:52 [INFO]   - sx128x-util (sx128x-util-x86_64-unknown-linux-gnu -> /home/testpsko/.cargo/bin/sx128x-util-v0.17.2)
15:28:52 [INFO] And create (or update) the following symlinks:
15:28:52 [INFO]   - sx128x-util (/home/testpsko/.cargo/bin/sx128x-util -> sx128x-util-v0.17.2)
15:28:52 [INFO] Do you wish to continue? yes/no
yes
15:28:54 [INFO] Installing binaries...
15:28:54 [INFO] Installation complete!

testpsko@tarta:~$ ls -lh ~/.cargo/bin/
total 81M
-rwxr-xr-x 12 testpsko testpsko  15M Mar 13 16:08 cargo
-rwxr-xr-x  1 testpsko testpsko  14M Mar 13 16:10 cargo-binstall
-rwxr-xr-x 12 testpsko testpsko  15M Mar 13 16:08 cargo-clippy
-rwxr-xr-x 12 testpsko testpsko  15M Mar 13 16:08 cargo-fmt
-rwxr-xr-x 12 testpsko testpsko  15M Mar 13 16:08 cargo-miri
-rwxr-xr-x 12 testpsko testpsko  15M Mar 13 16:08 clippy-driver
-rwxr-xr-x 12 testpsko testpsko  15M Mar 13 16:08 rls
-rwxr-xr-x 12 testpsko testpsko  15M Mar 13 16:08 rustc
-rwxr-xr-x 12 testpsko testpsko  15M Mar 13 16:08 rustdoc
-rwxr-xr-x 12 testpsko testpsko  15M Mar 13 16:08 rustfmt
-rwxr-xr-x 12 testpsko testpsko  15M Mar 13 16:08 rust-gdb
-rwxr-xr-x 12 testpsko testpsko  15M Mar 13 16:08 rust-lldb
-rwxr-xr-x 12 testpsko testpsko  15M Mar 13 16:08 rustup
lrwxrwxrwx  1 testpsko testpsko   19 Mar 13 16:28 sx128x-util -> sx128x-util-v0.17.2
-rwxr-xr-x  1 testpsko testpsko 6.6M Mar 13 16:28 sx128x-util-v0.17.2
```

Closes #103