### PR TITLE
Clarify --version usage and add a warning at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,7 @@ dependencies = [
  "env_logger",
  "flate2",
  "log",
+ "regex",
  "reqwest",
  "semver",
  "serde",
@@ -1186,9 +1187,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,6 @@ dependencies = [
  "env_logger",
  "flate2",
  "log",
- "regex",
  "reqwest",
  "semver",
  "serde",
@@ -1357,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0486718e92ec9a68fbed73bb5ef687d71103b142595b406835649bebd33f72c7"
+checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ xz2 = "0.1.6"
 zip = "0.5.13"
 async-trait = "0.1.52"
 url = "2.2.2"
+regex = "1.5.5"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,11 @@ strum_macros = "0.23.1"
 strum = "0.23.0"
 dirs = "4.0.0"
 crates-index = "0.18.5"
-semver = "1.0.5"
+semver = "1.0.7"
 xz2 = "0.1.6"
 zip = "0.5.13"
 async-trait = "0.1.52"
 url = "2.2.2"
-regex = "1.5.5"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/src/bins.rs
+++ b/src/bins.rs
@@ -1,4 +1,4 @@
-use std::path::{PathBuf, Path};
+use std::path::{Path, PathBuf};
 
 use cargo_toml::Product;
 use log::debug;
@@ -118,9 +118,13 @@ impl BinFile {
 
     fn link_dest(&self) -> &Path {
         #[cfg(target_family = "unix")]
-        { Path::new(self.dest.file_name().unwrap()) }
+        {
+            Path::new(self.dest.file_name().unwrap())
+        }
         #[cfg(target_family = "windows")]
-        { &self.dest }
+        {
+            &self.dest
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,19 @@ async fn main() -> Result<(), anyhow::Error> {
     let manifest = load_manifest_path(manifest_path.join("Cargo.toml"))?;
     let package = manifest.package.unwrap();
 
+    let plain_version_rx = regex::Regex::new(r"^\d+[.]\d+[.]\d+(-\w+([.]\d+)?)?$").unwrap();
+    if plain_version_rx.is_match(&opts.version) && package.version != opts.version {
+        warn!(
+            "You specified `--version {o}` but the package resolved that to '{p}', use `={o}` if you want an exact match",
+            o=opts.version, p=package.version
+        );
+
+        if !opts.no_confirm && !opts.dry_run && !confirm()? {
+            warn!("Installation cancelled");
+            return Ok(());
+        }
+    }
+
     let (mut meta, binaries) = (
         package
             .metadata

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{path::PathBuf, str::FromStr};
 
 use log::{debug, error, info, warn, LevelFilter};
 use simplelog::{ColorChoice, ConfigBuilder, TermLogger, TerminalMode};
@@ -105,8 +105,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let manifest = load_manifest_path(manifest_path.join("Cargo.toml"))?;
     let package = manifest.package.unwrap();
 
-    let plain_version_rx = regex::Regex::new(r"^\d+[.]\d+[.]\d+(-\w+([.]\d+)?)?$").unwrap();
-    if plain_version_rx.is_match(&opts.version) && package.version != opts.version {
+    let is_plain_version = semver::Version::from_str(&opts.version).is_ok();
+    if is_plain_version && package.version != opts.version {
         warn!(
             "You specified `--version {o}` but the package resolved that to '{p}', use `={o}` if you want an exact match",
             o=opts.version, p=package.version

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,8 @@ struct Options {
     #[structopt()]
     name: String,
 
-    /// Filter for package version to install
+    /// Filter for package version to install, in Cargo.toml format.
+    /// Use `=1.2.3` to install a specific version.
     #[structopt(long, default_value = "*")]
     version: String,
 


### PR DESCRIPTION
Fixes #113

Did both:
- Help message is fixed up to mention that it's the same syntax/semantics as a Cargo.toml version field
- When using `--version 1.2.3` and the version resolves to something different, warn and reconfirm.