### PR TITLE
feat: add release build optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,12 @@ pkg-fmt = "zip"
 [package.metadata.binstall.overrides.x86_64-apple-darwin]
 pkg-fmt = "zip"
 
+# makes sure release builds are well optimized
+[profile.release]
+lto = "fat"
+codegen-units = 1
+debug = true
+
 [dependencies]
 anyhow = "1.0.57"
 async-trait = "0.1.52"


### PR DESCRIPTION
This adds some release build optimizations.

IMO, release builds for binaries should be well optimized. Some of the options such as the `opt-level` are usually set by the compiler by default, but they are there so 1) its clear what it uses 2) to overwrite what dependencies might specify.

@passcod should be fimiliar with these, as they are (almost all) used over at `cargo-watch`

More info about some of these:
- https://docs.rust-embedded.org/book/unsorted/speed-vs-size.html
- https://deterministic.space/high-performance-rust.html

FYI, yes I know `cargo-binstall` doesn't have a hell lot of code but commitment is the name of the game

Happy to receive feedback