### PR TITLE
fix: ignore crate version if yanked

### DIFF
--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -83,7 +83,13 @@ pub async fn fetch_crate_cratesio(
     };
 
     // Locate matching version
-    let version_iter = base_info.versions().iter().map(|v| v.version());
+    let version_iter = base_info.versions().iter().filter_map(|v| {
+        if !v.is_yanked() {
+            Some(v.version())
+        } else {
+            None
+        }
+    });
     let version_name = find_version(version_req, version_iter)?;
 
     // Build crates.io api client


### PR DESCRIPTION
This should do the trick for #113 to ignore yanked versions. Filtering these out just before finding a matching version