### PR TITLE
fix: abort install for specific version if not confirmed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ async fn main() -> Result<(), anyhow::Error> {
             o=opts.version, p=package.version
         );
 
-        if !opts.no_confirm && !opts.dry_run && !confirm()? {
+        if opts.no_confirm || opts.dry_run || !confirm()? {
             warn!("Installation cancelled");
             return Ok(());
         }


### PR DESCRIPTION
This should fix the case for #113 where `--no-confirm` or `--dry-run` just continues to install