### PR TITLE
feat: use in memory extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,21 +139,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "cargo-binstall"
 version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "cargo_metadata",
+ "bytes",
  "cargo_toml",
  "crates-index",
  "crates_io_api",
@@ -169,34 +160,11 @@ dependencies = [
  "strum",
  "strum_macros",
  "tar",
- "tempdir",
  "tinytemplate",
  "tokio",
  "url",
  "xz2",
  "zip",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -476,12 +444,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
+checksum = "5e77a14ffc6ba4ad5188d6cf428894c4fcfda725326b37558f35bb677e712cec"
 dependencies = [
  "bitflags",
  "libc",
@@ -818,15 +780,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.124"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a41fed9d98f27ab1c6d161da622a4fa35e8a54a8adc24bbf3ddd0ef70b0e50"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.2+1.4.2"
+version = "0.13.3+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
+checksum = "c24d36c3ac9b9996a2418d6bf428cc0bc5d1a814a84303fc60986088c5ed60de"
 dependencies = [
  "cc",
  "libc",
@@ -900,9 +862,9 @@ checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
@@ -962,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -1041,9 +1003,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1059,7 +1021,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
 dependencies = [
  "base64ct",
- "rand_core 0.6.3",
+ "rand_core",
  "subtle",
 ]
 
@@ -1142,34 +1104,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
 name = "rand_core"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,15 +1131,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -1244,15 +1169,6 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -1367,24 +1283,21 @@ name = "semver"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1393,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "f972498cf015f7c0746cac89ebe1d6ef10c293b94175a243a2d9442c163d9944"
 dependencies = [
  "itoa",
  "ryu",
@@ -1559,9 +1472,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1577,16 +1490,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand",
- "remove_dir_all",
 ]
 
 [[package]]
@@ -1609,18 +1512,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2004,9 +1907,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -2017,33 +1920,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ pkg-fmt = "zip"
 [dependencies]
 anyhow = "1.0.57"
 async-trait = "0.1.52"
-cargo_metadata = "0.14.2"
+bytes = "1.1.0"
 cargo_toml = "0.11.4"
 crates-index = "0.18.7"
 crates_io_api = { version = "0.8.0", default-features = false, features = ["rustls"] }
@@ -36,7 +36,6 @@ structopt = "0.3.26"
 strum = "0.24.0"
 strum_macros = "0.24.0"
 tar = "0.4.38"
-tempdir = "0.3.7"
 tinytemplate = "1.2.1"
 tokio = { version = "1.18.0", features = [ "full" ] }
 url = "2.2.2"

--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -2,13 +2,16 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{anyhow, Context};
+use cargo_toml::Manifest;
 use log::debug;
 use semver::{Version, VersionReq};
 
 use crates_io_api::AsyncClient;
 
 use crate::helpers::*;
+use crate::Meta;
 use crate::PkgFmt;
+use std::str::FromStr;
 
 fn find_version<'a, V: Iterator<Item = &'a str>>(
     requirement: &str,
@@ -21,7 +24,7 @@ fn find_version<'a, V: Iterator<Item = &'a str>>(
     let mut filtered: Vec<_> = version_iter
         .filter(|v| {
             // Remove leading `v` for git tags
-            let ver_str = match v.strip_prefix("s") {
+            let ver_str = match v.strip_prefix('s') {
                 Some(v) => v,
                 None => v,
             };
@@ -60,11 +63,10 @@ fn find_version<'a, V: Iterator<Item = &'a str>>(
 }
 
 /// Fetch a crate by name and version from crates.io
-pub async fn fetch_crate_cratesio(
+pub async fn fetch_manifest_cratesio(
     name: &str,
     version_req: &str,
-    temp_dir: &Path,
-) -> Result<PathBuf, anyhow::Error> {
+) -> Result<Manifest<Meta>, anyhow::Error> {
     // Fetch / update index
     debug!("Updating crates.io index");
     let mut index = crates_index::Index::new_cargo_default()?;
@@ -119,21 +121,23 @@ pub async fn fetch_crate_cratesio(
     debug!("Found information for crate version: '{}'", version.num);
 
     // Download crate to temporary dir (crates.io or git?)
-    let crate_url = format!("https://crates.io/{}", version.dl_path);
-    let tgz_path = temp_dir.join(format!("{}.tgz", name));
+    let crate_url = format!("https://crates.io{}", version.dl_path);
 
     debug!("Fetching crate from: {}", crate_url);
 
     // Download crate
-    download(&crate_url, &tgz_path).await?;
+    let crate_data = download(&crate_url).await?;
 
     // Decompress downloaded tgz
     debug!("Decompressing crate archive");
-    extract(&tgz_path, PkgFmt::Tgz, &temp_dir)?;
-    let crate_path = temp_dir.join(format!("{}-{}", name, version_name));
+    let raw_manifest = extract_file(
+        &crate_data,
+        PkgFmt::Tgz,
+        PathBuf::from_str(&format!("{}-{}/Cargo.toml", name, version_name)).unwrap(),
+    )?;
 
     // Return crate directory
-    Ok(crate_path)
+    Ok(Manifest::<Meta>::from_slice_with_metadata(&raw_manifest)?)
 }
 
 /// Fetch a crate by name and version from github

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use log::info;
 use reqwest::Method;
 
@@ -32,10 +30,10 @@ impl super::Fetcher for QuickInstall {
         remote_exists(&url, Method::HEAD).await
     }
 
-    async fn fetch(&self, dst: &Path) -> Result<(), anyhow::Error> {
+    async fn fetch(&self) -> Result<bytes::Bytes, anyhow::Error> {
         let url = self.package_url();
         info!("Downloading package from: '{url}'");
-        download(&url, &dst).await
+        download(&url).await
     }
 
     fn pkg_fmt(&self) -> PkgFmt {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,14 +13,14 @@ pub mod bins;
 pub mod fetchers;
 
 /// Compiled target triple, used as default for binary fetching
-pub const TARGET: &'static str = env!("TARGET");
+pub const TARGET: &str = env!("TARGET");
 
 /// Default package path template (may be overridden in package Cargo.toml)
-pub const DEFAULT_PKG_URL: &'static str =
+pub const DEFAULT_PKG_URL: &str =
     "{ repo }/releases/download/v{ version }/{ name }-{ target }-v{ version }.{ archive-format }";
 
 /// Default binary name template (may be overridden in package Cargo.toml)
-pub const DEFAULT_BIN_DIR: &'static str = "{ name }-{ target }-v{ version }/{ bin }{ binary-ext }";
+pub const DEFAULT_BIN_DIR: &str = "{ name }-{ target }-v{ version }/{ bin }{ binary-ext }";
 
 /// Binary format enumeration
 #[derive(
@@ -108,7 +108,7 @@ impl PkgMeta {
 /// Target specific overrides for binary installation
 ///
 /// Exposed via `[package.metadata.TARGET]` in `Cargo.toml`
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case", default)]
 pub struct PkgOverride {
     /// URL template override for package downloads
@@ -119,16 +119,6 @@ pub struct PkgOverride {
 
     /// Path template override for binary files in packages
     pub bin_dir: Option<String>,
-}
-
-impl Default for PkgOverride {
-    fn default() -> Self {
-        Self {
-            pkg_url: None,
-            pkg_fmt: None,
-            bin_dir: None,
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -157,9 +147,9 @@ mod test {
         let mut manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
         manifest_dir.push_str("/Cargo.toml");
 
-        let manifest = load_manifest_path(&manifest_dir).expect("Error parsing metadata");
+        let manifest = load_manifest_path(manifest_dir.into()).expect("Error parsing metadata");
         let package = manifest.package.unwrap();
-        let meta = package.metadata.map(|m| m.binstall).flatten().unwrap();
+        let meta = package.metadata.and_then(|m| m.binstall).unwrap();
 
         assert_eq!(&package.name, "cargo-binstall");
 


### PR DESCRIPTION
The dependency `tempdir` is deprecated and unmaintained since 2018 and got moved into `tempfile`. But why would this crate need a temporary directory if it know what files its looking for?

I tried to implement this in a way to not to have to copy thing over and over again and work with types which are already returned and used by crates such as `reqwest`.

Quickly tried it with `cargo-watch` (provided via repo itself) and `cargo-all-features` (provided via quickinstall)

Would love to have feedback on this.

__Edit__: this would also mean that the falg `--no-cleanup` would be gone as there would be no cleanup, some changes may also be from `cargo clippy`