### PR TITLE
feat: parallel iterations and sorting using rayon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "env_logger",
  "flate2",
  "log",
+ "rayon",
  "reqwest",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ crates_io_api = { version = "0.8.0", default-features = false, features = ["rust
 dirs = "4.0.0"
 flate2 = "1.0.22"
 log = "0.4.14"
+rayon = "1.5.2"
 reqwest = { version = "0.11.10", features = [ "rustls-tls" ], default-features = false }
 semver = "1.0.7"
 serde = { version = "1.0.136", features = [ "derive" ] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use simplelog::{ColorChoice, ConfigBuilder, TermLogger, TerminalMode};
 use structopt::StructOpt;
 use tempdir::TempDir;
 use tokio::process::Command;
+use rayon::prelude::*;
 
 use cargo_binstall::{
     bins,
@@ -275,7 +276,7 @@ async fn install_from_package(
     };
 
     let bin_files = binaries
-        .iter()
+        .par_iter()
         .map(|p| bins::BinFile::from_product(&bin_data, p))
         .collect::<Result<Vec<_>, anyhow::Error>>()?;
 


### PR DESCRIPTION
It's a fact that crates.io is growing and a crate like `cargo-watch` already has 57 versions. I know the rust community is split about the use of `rayon` in many cases. I know it doesn't have a huge impact for this crate, but why not benefit from it anyways?

Some for loops can just not be parallelized as they are printing out statements in certain orders, nevertheless things like version selection do see a benefit. i.e. of `cargo-watch` I do see a reduction of min 200ms on my machine.

If I know if #130 makes it, I could try to implement it in its extraction