### PR TITLE
feat: flags to disable third-party and from source installs

### DIFF
--- a/src/bins.rs
+++ b/src/bins.rs
@@ -47,7 +47,9 @@ impl BinFile {
         let dest = data.install_path.join(dest_file_path);
 
         // Link at install dir + base-name{.extension}
-        let link = data.install_path.join(&ctx.render("{ bin }{ binary-ext }")?);
+        let link = data
+            .install_path
+            .join(&ctx.render("{ bin }{ binary-ext }")?);
 
         Ok(Self {
             base_name,

--- a/src/fetchers.rs
+++ b/src/fetchers.rs
@@ -52,17 +52,19 @@ impl MultiFetcher {
         self.fetchers.push(fetcher);
     }
 
-    pub async fn first_available(&self) -> Option<&dyn Fetcher> {
+    pub async fn first_available(&self, allow_third_party_sources: bool) -> Option<&dyn Fetcher> {
         for fetcher in &self.fetchers {
-            if fetcher.check().await.unwrap_or_else(|err| {
-                debug!(
-                    "Error while checking fetcher {}: {}",
-                    fetcher.source_name(),
-                    err
-                );
-                false
-            }) {
-                return Some(&**fetcher);
+            if allow_third_party_sources || !fetcher.is_third_party() {
+                if fetcher.check().await.unwrap_or_else(|err| {
+                    debug!(
+                        "Error while checking fetcher {}: {}",
+                        fetcher.source_name(),
+                        err
+                    );
+                    false
+                }) {
+                    return Some(&**fetcher);
+                }
             }
         }
 


### PR DESCRIPTION
In some cases where I know the owner of the project does have it's crate setup to support `cargo-binstall` I would like to make sure that it's not using third party installs or falling back to `cargo install`.

I thought about something like `--no-fallback` but this would give it more selective options, so you could either disable the use of `cargo-install` or just exclude any third party installs.

This might also be helpful to point something out as https://github.com/watchexec/cargo-watch/issues/199