### PR TITLE
Add more targets for prebuilt binaries

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,31 +66,17 @@ jobs:
           target
 
     - name: Install cross toolchain (armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}
-      run: sudo apt-get install gcc-arm-linux-gnueabihf
-
-    - name: Install cross toolchain (armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
+      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }} || ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
       run: sudo apt-get install gcc-arm-linux-gnueabihf
 
     - name: Enable cross compilation (armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}
-      run: |
-        echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
-        echo "LZMA_API_STATIC=1" >> $GITHUB_ENV
-
-    - name: Enable cross compilation (armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
+      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }} || ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
       run: |
         echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
         echo "LZMA_API_STATIC=1" >> $GITHUB_ENV
 
     - name: Install musl-tools
-      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
-      run: sudo apt-get install -y musl-tools
-
-    - name: Install musl-tools
-      if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }} || ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
       run: sudo apt-get install -y musl-tools
 
     - name: Build release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-musl
+          - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             output: cargo-binstall
             archive: tgz
@@ -27,7 +27,7 @@ jobs:
             os: macos-latest
             output: cargo-binstall
             archive: zip
-          - target: armv7-unknown-linux-musleabihf
+          - target: armv7-unknown-linux-gnueabihf
             os: ubuntu-20.04
             output: cargo-binstall
             archive: tgz
@@ -35,6 +35,14 @@ jobs:
             os: windows-latest
             output: cargo-binstall.exe
             archive: zip
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            output: cargo-binstall
+            archive: tgz
+          - target: armv7-unknown-linux-musleabihf
+            os: ubuntu-20.04
+            output: cargo-binstall
+            archive: tgz
 
     steps:
     - uses: actions/checkout@v2
@@ -47,6 +55,13 @@ jobs:
         target:  ${{ matrix.target }}
         override: true
  
+    - name: Install openssl (apt armv7)
+      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}
+      uses: ryankurte/action-apt@v0.3.0
+      with:
+        arch: armhf
+        packages: libssl-dev:armhf libssl1.1:armhf zlib1g-dev:armhf zlib1g:armhf libc-dev:armhf
+
     - name: Install openssl (apt armv7)
       if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
       uses: ryankurte/action-apt@v0.3.0
@@ -65,8 +80,18 @@ jobs:
           target
 
     - name: Install cross toolchain (armv7)
+      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}
+      run: sudo apt-get install gcc-arm-linux-gnueabihf
+
+    - name: Install cross toolchain (armv7)
       if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
       run: sudo apt-get install gcc-arm-linux-gnueabihf
+
+    - name: Enable cross compilation (armv7)
+      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}
+      run: |
+        echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
+        echo "LZMA_API_STATIC=1" >> $GITHUB_ENV
 
     - name: Enable cross compilation (armv7)
       if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,20 +54,6 @@ jobs:
         toolchain: nightly
         target:  ${{ matrix.target }}
         override: true
- 
-    - name: Install openssl (apt armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}
-      uses: ryankurte/action-apt@v0.3.0
-      with:
-        arch: armhf
-        packages: libssl-dev:armhf libssl1.1:armhf zlib1g-dev:armhf zlib1g:armhf libc-dev:armhf
-
-    - name: Install openssl (apt armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
-      uses: ryankurte/action-apt@v0.3.0
-      with:
-        arch: armhf
-        packages: libssl-dev:armhf libssl1.1:armhf zlib1g-dev:armhf zlib1g:armhf libc-dev:armhf
 
     - name: Configure caching
       uses: actions/cache@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -49,6 +49,16 @@ jobs:
             output: cargo-binstall
             archive: tgz
             use-cross: true
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            output: cargo-binstall
+            archive: tgz
+            use-cross: true
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            output: cargo-binstall
+            archive: tgz
+            use-cross: true
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -164,6 +164,10 @@ jobs:
             os: windows-latest
             output: cargo-binstall.exe
             archive: zip
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            output: cargo-binstall
+            archive: tgz
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         key: ${{ matrix.os }}-${{ matrix.target }}
         path: |
-          ${{ env.HOME }}/.cargo"
+          ${{ env.HOME }}/.cargo
           target
 
     - name: Install cross toolchain (armv7)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -160,10 +160,6 @@ jobs:
         target:  ${{ matrix.target }}
         override: true
 
-    - name: Install musl-tools
-      if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
-      run: sudo apt-get install -y musl-tools
-
     - uses: actions/download-artifact@v2
       with:
         name: cargo-binstall-${{ matrix.target }}.${{ matrix.archive }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             output: cargo-binstall
             archive: tgz
@@ -27,7 +27,7 @@ jobs:
             os: macos-latest
             output: cargo-binstall
             archive: zip
-          - target: armv7-unknown-linux-gnueabihf
+          - target: armv7-unknown-linux-musleabihf
             os: ubuntu-20.04
             output: cargo-binstall
             archive: tgz
@@ -48,7 +48,7 @@ jobs:
         override: true
  
     - name: Install openssl (apt armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}
+      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
       uses: ryankurte/action-apt@v0.3.0
       with:
         arch: armhf
@@ -65,14 +65,22 @@ jobs:
           target
 
     - name: Install cross toolchain (armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}
-      run: sudo apt install gcc-arm-linux-gnueabihf
+      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
+      run: sudo apt install gcc-arm-linux-musleabihf
 
     - name: Enable cross compilation (armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }}
+      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
       run: |
         echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
         echo "LZMA_API_STATIC=1" >> $GITHUB_ENV
+
+    - name: Install musl-tools
+      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
+      run: sudo apt-get install -y musl-tools
+
+    - name: Install musl-tools
+      if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+      run: sudo apt-get install -y musl-tools
 
     - name: Build release
       uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -154,6 +154,16 @@ jobs:
     - uses: actions/checkout@v2
     - uses: FranzDiebold/github-env-vars-action@v1.2.1
 
+    - name: Configure toolchain
+      if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+      uses: actions-rs/toolchain@v1
+      with:
+        target:  ${{ matrix.target }}
+
+    - name: Install musl-tools
+      if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+      run: sudo apt-get install -y musl-tools
+
     - uses: actions/download-artifact@v2
       with:
         name: cargo-binstall-${{ matrix.target }}.${{ matrix.archive }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
             os: ubuntu-20.04
             output: cargo-binstall
             archive: tgz
-            use-cross: false
+            use-cross: true
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             output: cargo-binstall.exe
@@ -71,18 +71,8 @@ jobs:
           ${{ env.HOME }}/.cargo
           target
 
-    - name: Install cross toolchain (armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' || matrix.target == 'armv7-unknown-linux-musleabihf' }}
-      run: sudo apt-get install gcc-arm-linux-gnueabihf
-
-    - name: Enable cross compilation (armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' || matrix.target == 'armv7-unknown-linux-musleabihf' }}
-      run: |
-        echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
-        echo "LZMA_API_STATIC=1" >> $GITHUB_ENV
-
     - name: Install musl-tools
-      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' || matrix.target == 'x86_64-unknown-linux-musl' }}
+      if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
       run: sudo apt-get install -y musl-tools
 
     - name: Build release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,10 +80,19 @@ jobs:
       run: sudo apt-get install -y musl-tools
 
     - name: Build release
+      if: ${{ matrix.target != 'armv7-unknown-linux-musleabihf' }}
       uses: actions-rs/cargo@v1
       with:
         command: build
         args: --target ${{ matrix.target }} --release
+
+    - name: Build release for armv7 musl target
+      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --target ${{ matrix.target }} --release
+        use-cross: true
 
     - name: Copy and rename utility
       run: cp target/${{ matrix.target }}/release/${{ matrix.output }} ${{ matrix.output }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -158,7 +158,9 @@ jobs:
       if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
       uses: actions-rs/toolchain@v1
       with:
+        toolchain: stable
         target:  ${{ matrix.target }}
+        override: true
 
     - name: Install musl-tools
       if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,17 +66,17 @@ jobs:
           target
 
     - name: Install cross toolchain (armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }} || ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
+      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' || matrix.target == 'armv7-unknown-linux-musleabihf' }}
       run: sudo apt-get install gcc-arm-linux-gnueabihf
 
     - name: Enable cross compilation (armv7)
-      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' }} || ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
+      if: ${{ matrix.target == 'armv7-unknown-linux-gnueabihf' || matrix.target == 'armv7-unknown-linux-musleabihf' }}
       run: |
         echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
         echo "LZMA_API_STATIC=1" >> $GITHUB_ENV
 
     - name: Install musl-tools
-      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }} || ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' || matrix.target == 'x86_64-unknown-linux-musl' }}
       run: sudo apt-get install -y musl-tools
 
     - name: Build release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Install cross toolchain (armv7)
       if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
-      run: sudo apt install gcc-arm-linux-musleabihf
+      run: sudo apt-get install gcc-arm-linux-gnueabihf
 
     - name: Enable cross compilation (armv7)
       if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,26 +23,32 @@ jobs:
             os: ubuntu-latest
             output: cargo-binstall
             archive: tgz
+            use-cross: false
           - target: x86_64-apple-darwin
             os: macos-latest
             output: cargo-binstall
             archive: zip
+            use-cross: false
           - target: armv7-unknown-linux-gnueabihf
             os: ubuntu-20.04
             output: cargo-binstall
             archive: tgz
+            use-cross: false
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             output: cargo-binstall.exe
             archive: zip
+            use-cross: false
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             output: cargo-binstall
             archive: tgz
+            use-cross: false
           - target: armv7-unknown-linux-musleabihf
             os: ubuntu-20.04
             output: cargo-binstall
             archive: tgz
+            use-cross: true
 
     steps:
     - uses: actions/checkout@v2
@@ -80,19 +86,11 @@ jobs:
       run: sudo apt-get install -y musl-tools
 
     - name: Build release
-      if: ${{ matrix.target != 'armv7-unknown-linux-musleabihf' }}
       uses: actions-rs/cargo@v1
       with:
         command: build
         args: --target ${{ matrix.target }} --release
-
-    - name: Build release for armv7 musl target
-      if: ${{ matrix.target == 'armv7-unknown-linux-musleabihf' }}
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --target ${{ matrix.target }} --release
-        use-cross: true
+        use-cross: ${{ matrix.use-cross }}
 
     - name: Copy and rename utility
       run: cp target/${{ matrix.target }}/release/${{ matrix.output }} ${{ matrix.output }}


### PR DESCRIPTION
Add musl target which provides prebuilt binaries statically linked with musl libc and does not depend on any dynamic
library, thus can be run anywhere.

I've verified that for `x86_64`, the binary built by job `build` does not contain any dynamic dependency and can work in ubuntu container and I also added it to job `test`, though it currently failed to build `cargo-binstall` as v0.7.0 requires openssl, but will be automatically fixed once a new release is made.

I also added target `aarch64` with both glibc and musl libc.

~~The `arm-linux-musleabihf-gcc` on the other hand is missing on arm build and I don't know how to fix this.~~

Fixed by using `use-cross: true`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>