### PR TITLE
Optimize release build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,6 +96,8 @@ jobs:
         command: build
         args: --target ${{ matrix.target }} --release
         use-cross: ${{ matrix.use-cross }}
+      env:
+        RUSTFLAGS: -Zstrip=symbols
 
     - name: Copy and rename utility
       run: cp target/${{ matrix.target }}/release/${{ matrix.output }} ${{ matrix.output }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,6 +96,8 @@ jobs:
         command: build
         args: --target ${{ matrix.target }} --release
         use-cross: ${{ matrix.use-cross }}
+      env:
+        RUSTFLAGS: -Cstrip=symbols
 
     - name: Copy and rename utility
       run: cp target/${{ matrix.target }}/release/${{ matrix.output }} ${{ matrix.output }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,6 +100,10 @@ jobs:
     - name: Copy and rename utility
       run: cp target/${{ matrix.target }}/release/${{ matrix.output }} ${{ matrix.output }}
 
+    - name: Strip the executable
+      if: ${{ matrix.os != 'windows-latest' }}
+      run: strip ${{ matrix.output }}
+
     - name: Create archive (tgz, linux)
       if: ${{ matrix.os != 'macos-latest' && matrix.os != 'windows-latest' }}
       run: tar -czvf cargo-binstall-${{ matrix.target }}.tgz ${{ matrix.output }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,8 +96,6 @@ jobs:
         command: build
         args: --target ${{ matrix.target }} --release
         use-cross: ${{ matrix.use-cross }}
-      env:
-        RUSTFLAGS: -Cstrip=symbols
 
     - name: Copy and rename utility
       run: cp target/${{ matrix.target }}/release/${{ matrix.output }} ${{ matrix.output }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,8 +96,6 @@ jobs:
         command: build
         args: --target ${{ matrix.target }} --release
         use-cross: ${{ matrix.use-cross }}
-      env:
-        RUSTFLAGS: -Zstrip=symbols
 
     - name: Copy and rename utility
       run: cp target/${{ matrix.target }}/release/${{ matrix.output }} ${{ matrix.output }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -100,10 +100,6 @@ jobs:
     - name: Copy and rename utility
       run: cp target/${{ matrix.target }}/release/${{ matrix.output }} ${{ matrix.output }}
 
-    - name: Strip the executable
-      if: ${{ matrix.os != 'windows-latest' }}
-      run: strip ${{ matrix.output }}
-
     - name: Create archive (tgz, linux)
       if: ${{ matrix.os != 'macos-latest' && matrix.os != 'windows-latest' }}
       run: tar -czvf cargo-binstall-${{ matrix.target }}.tgz ${{ matrix.output }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,8 @@ zip = "0.6.2"
 
 [dev-dependencies]
 env_logger = "0.9.0"
+
+[profile.release]
+lto = true
+codegen-units = 1
+panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,4 @@ env_logger = "0.9.0"
 lto = true
 codegen-units = 1
 panic = "abort"
+strip = "symbols"


### PR DESCRIPTION
by enabling lto, setting `codegen-units` to 1 and setting panic behavior
to `abort`.

On my `aarch64-apple-darwin` with `rustc 1.61.0`, this reduces the size
of binary from `7.8M` to `4.9M`.

Edit:

With `RUSTFLAGS=-Zstrip=symbols`, I was able to further reduce the size of binary to `3.8M` on my Macbook Air.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>