### PR TITLE
Clap 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap",
+ "clap 2.34.0",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -144,6 +144,7 @@ dependencies = [
  "async-trait",
  "cargo_metadata",
  "cargo_toml",
+ "clap 3.1.18",
  "crates_io_api",
  "dirs",
  "env_logger",
@@ -155,7 +156,6 @@ dependencies = [
  "semver",
  "serde",
  "simplelog",
- "structopt",
  "strum",
  "strum_macros",
  "tar",
@@ -257,10 +257,49 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -567,15 +606,6 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
 
 [[package]]
 name = "heck"
@@ -923,6 +953,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+
+[[package]]
 name = "owo-colors"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1261,28 +1297,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
@@ -1296,7 +1314,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -1594,12 +1612,6 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ pkg-fmt = "zip"
 async-trait = "0.1.56"
 cargo_metadata = "0.14.2"
 cargo_toml = "0.11.4"
+clap = { version = "3.1.18", features = ["derive"] }
 crates_io_api = { version = "0.8.0", default-features = false, features = ["rustls"] }
 dirs = "4.0.0"
 flate2 = { version = "1.0.24", features = ["zlib-ng"], default-features = false }
@@ -31,7 +32,6 @@ reqwest = { version = "0.11.10", features = [ "rustls-tls" ], default-features =
 semver = "1.0.7"
 serde = { version = "1.0.136", features = [ "derive" ] }
 simplelog = "0.12.0"
-structopt = "0.3.26"
 strum = "0.24.0"
 strum_macros = "0.24.0"
 tar = "0.4.38"

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -77,6 +77,11 @@ impl QuickInstall {
     }
 
     pub async fn report(&self) -> Result<(), BinstallError> {
+        if cfg!(debug_assertions) {
+            debug!("Not sending quickinstall report in debug mode");
+            return Ok(());
+        }
+
         let url = Url::parse(&self.stats_url())?;
         debug!("Sending installation report to quickinstall ({url})");
 

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use log::info;
+use log::{debug, info};
 use reqwest::Method;
 use url::Url;
 
@@ -77,8 +77,9 @@ impl QuickInstall {
     }
 
     pub async fn report(&self) -> Result<(), BinstallError> {
-        info!("Sending installation report to quickinstall (anonymous)");
         let url = Url::parse(&self.stats_url())?;
+        debug!("Sending installation report to quickinstall ({url})");
+
         reqwest::Client::builder()
             .user_agent(USER_AGENT)
             .build()?

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,6 +181,7 @@ async fn entry() -> Result<()> {
     let mut log_config = ConfigBuilder::new();
     log_config.add_filter_ignore("hyper".to_string());
     log_config.add_filter_ignore("reqwest".to_string());
+    log_config.add_filter_ignore("rustls".to_string());
     log_config.set_location_level(LevelFilter::Off);
     TermLogger::init(
         opts.log_level,

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,14 +23,14 @@ use cargo_binstall::{
 #[derive(Debug, Parser)]
 #[clap(version, about = "Install a Rust binary... from binaries!")]
 struct Options {
-    /// Package name or URL for installation.
-    /// 
-    /// This must be either a crates.io package name or github or gitlab URL.
+    /// Package name for installation.
+    ///
+    /// This must be a crates.io package name.
     #[clap(value_name = "crate")]
     name: String,
 
     /// Semver filter to select the package version to install.
-    /// 
+    ///
     /// This is in Cargo.toml dependencies format: `--version 1.2.3` is equivalent to
     /// `--version "^1.2.3"`. Use `=1.2.3` to install a specific version.
     #[clap(long, default_value = "*")]
@@ -41,17 +41,17 @@ struct Options {
     target: Option<String>,
 
     /// Override install path for downloaded binary.
-    /// 
+    ///
     /// Defaults to `$HOME/.cargo/bin`
     #[clap(help_heading = "OVERRIDES", long)]
     install_path: Option<String>,
 
     /// Disable symlinking / versioned updates.
-    /// 
+    ///
     /// By default, Binstall will install a binary named `<name>-<version>` in the install path, and
     /// either symlink or copy it to (depending on platform) the plain binary name. This makes it
     /// possible to have multiple versions of the same binary, for example for testing or rollback.
-    /// 
+    ///
     /// Pass this flag to disable this behavior.
     #[clap(long)]
     no_symlinks: bool,
@@ -69,7 +69,7 @@ struct Options {
     no_cleanup: bool,
 
     /// Override manifest source.
-    /// 
+    ///
     /// This skips searching crates.io for a manifest and uses the specified path directly, useful
     /// for debugging and when adding Binstall support. This must be the path to the folder
     /// containing a Cargo.toml file, not the Cargo.toml file itself.
@@ -77,7 +77,7 @@ struct Options {
     manifest_path: Option<PathBuf>,
 
     /// Utility log level
-    /// 
+    ///
     /// Set to `debug` when submitting a bug report.
     #[clap(long, default_value = "info")]
     log_level: LevelFilter,

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ struct Options {
     #[clap(long, default_value = "*")]
     version: String,
 
-    /// Override binary target set. Defaults to a set of targets based on the current platform.
+    /// Override binary target set.
     ///
     /// Binstall is able to look for binaries for several targets, installing the first one it finds
     /// in the order the targets were given. For example, on a 64-bit glibc Linux distribution, the
@@ -45,13 +45,14 @@ struct Options {
     /// considered.
     ///
     /// This option takes a comma-separated list of target triples, which will be tried in order.
+    /// They override the default list, which is detected automatically from the current platform.
     ///
     /// If falling back to installing from source, the first target will be used.
     #[clap(
         help_heading = "OVERRIDES",
         alias = "target",
         long,
-        value_name = "triple"
+        value_name = "TRIPLE"
     )]
     targets: Option<String>,
 
@@ -94,7 +95,7 @@ struct Options {
     /// Utility log level
     ///
     /// Set to `debug` when submitting a bug report.
-    #[clap(long, default_value = "info")]
+    #[clap(long, default_value = "info", value_name = "LEVEL")]
     log_level: LevelFilter,
 
     /// Override Cargo.toml package manifest bin-dir.

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,49 +23,62 @@ use cargo_binstall::{
 #[derive(Debug, Parser)]
 #[clap(version, about = "Install a Rust binary... from binaries!")]
 struct Options {
-    /// Package name or URL for installation
-    /// This must be either a crates.io package name or github or gitlab url
+    /// Package name or URL for installation.
+    /// 
+    /// This must be either a crates.io package name or github or gitlab URL.
     #[clap(value_name = "crate")]
     name: String,
 
-    /// Filter for package version to install, in Cargo.toml format.
-    /// Use `=1.2.3` to install a specific version.
+    /// Semver filter to select the package version to install.
+    /// 
+    /// This is in Cargo.toml dependencies format: `--version 1.2.3` is equivalent to
+    /// `--version "^1.2.3"`. Use `=1.2.3` to install a specific version.
     #[clap(long, default_value = "*")]
     version: String,
 
-    /// Override binary target, ignoring compiled version
-    #[clap(help_heading = "OVERRIDES", long, default_value = TARGET)]
-    target: String,
+    /// Override binary target set. Defaults to a set of targets based on the current platform.
+    #[clap(help_heading = "OVERRIDES", long)]
+    target: Option<String>,
 
     /// Override install path for downloaded binary.
+    /// 
     /// Defaults to `$HOME/.cargo/bin`
     #[clap(help_heading = "OVERRIDES", long)]
     install_path: Option<String>,
 
-    /// Disable symlinking / versioned updates
+    /// Disable symlinking / versioned updates.
+    /// 
+    /// By default, Binstall will install a binary named `<name>-<version>` in the install path, and
+    /// either symlink or copy it to (depending on platform) the plain binary name. This makes it
+    /// possible to have multiple versions of the same binary, for example for testing or rollback.
+    /// 
+    /// Pass this flag to disable this behavior.
     #[clap(long)]
     no_symlinks: bool,
 
-    /// Dry run, fetch and show changes without installing binaries
+    /// Dry run, fetch and show changes without installing binaries.
     #[clap(long)]
     dry_run: bool,
 
-    /// Disable interactive mode / confirmation
+    /// Disable interactive mode / confirmation prompts.
     #[clap(long)]
     no_confirm: bool,
 
-    /// Do not cleanup temporary files on success
+    /// Do not cleanup temporary files.
     #[clap(long)]
     no_cleanup: bool,
 
     /// Override manifest source.
-    /// This skips searching crates.io for a manifest and uses
-    /// the specified path directly, useful for debugging and
-    /// when adding `binstall` support.
+    /// 
+    /// This skips searching crates.io for a manifest and uses the specified path directly, useful
+    /// for debugging and when adding Binstall support. This must be the path to the folder
+    /// containing a Cargo.toml file, not the Cargo.toml file itself.
     #[clap(help_heading = "OVERRIDES", long)]
     manifest_path: Option<PathBuf>,
 
     /// Utility log level
+    /// 
+    /// Set to `debug` when submitting a bug report.
     #[clap(long, default_value = "info")]
     log_level: LevelFilter,
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -126,7 +126,7 @@ mod linux {
             .expect("unwrap: TARGET always has a -")
             .0;
 
-        format!("{prefix}{libc_version}{abi}")
+        format!("{prefix}-{libc_version}{abi}")
     }
 }
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -123,8 +123,8 @@ mod linux {
     fn create_target_str(libc_version: &str, abi: &str) -> String {
         let prefix = TARGET
             .rsplit_once('-')
-            .map(|s| format!("{}-", s.0))
-            .unwrap_or_default();
+            .expect("unwrap: TARGET always has a -")
+            .0;
 
         format!("{prefix}{libc_version}{abi}")
     }

--- a/src/target.rs
+++ b/src/target.rs
@@ -18,13 +18,13 @@ pub const TARGET: &str = env!("TARGET");
 ///
 /// Check [this issue](https://github.com/ryankurte/cargo-binstall/issues/155)
 /// for more information.
-pub async fn detect_targets() -> Vec<Box<str>> {
+pub async fn detect_targets() -> Vec<String> {
     if let Some(target) = get_target_from_rustc().await {
         let mut v = vec![target];
 
         #[cfg(target_os = "linux")]
         if v[0].contains("gnu") {
-            v.push(v[0].replace("gnu", "musl").into_boxed_str());
+            v.push(v[0].replace("gnu", "musl"));
         }
 
         #[cfg(target_os = "macos")]
@@ -51,7 +51,7 @@ pub async fn detect_targets() -> Vec<Box<str>> {
 
 /// Figure out what the host target is using `rustc`.
 /// If `rustc` is absent, then it would return `None`.
-async fn get_target_from_rustc() -> Option<Box<str>> {
+async fn get_target_from_rustc() -> Option<String> {
     let Output { status, stdout, .. } = Command::new("rustc").arg("-vV").output().await.ok()?;
     if !status.success() {
         return None;
@@ -60,17 +60,14 @@ async fn get_target_from_rustc() -> Option<Box<str>> {
     Cursor::new(stdout)
         .lines()
         .filter_map(|line| line.ok())
-        .find_map(|line| {
-            line.strip_prefix("host: ")
-                .map(|host| host.to_owned().into_boxed_str())
-        })
+        .find_map(|line| line.strip_prefix("host: ").map(|host| host.to_owned()))
 }
 
 #[cfg(target_os = "linux")]
 mod linux {
     use super::{Command, Output, TARGET};
 
-    pub(super) async fn detect_targets_linux() -> Vec<Box<str>> {
+    pub(super) async fn detect_targets_linux() -> Vec<String> {
         let abi = parse_abi();
 
         if let Ok(Output {
@@ -123,16 +120,13 @@ mod linux {
         }
     }
 
-    fn create_target_str(libc_version: &str, abi: &str) -> Box<str> {
-        let prefix = TARGET.rsplit_once('-').unwrap().0;
+    fn create_target_str(libc_version: &str, abi: &str) -> String {
+        let prefix = TARGET
+            .rsplit_once('-')
+            .map(|s| format!("{}-", s.0))
+            .unwrap_or_default();
 
-        let mut target = String::with_capacity(prefix.len() + 1 + libc_version.len() + abi.len());
-        target.push_str(prefix);
-        target.push('-');
-        target.push_str(libc_version);
-        target.push_str(abi);
-
-        target.into_boxed_str()
+        format!("{prefix}{libc_version}{abi}")
     }
 }
 
@@ -143,7 +137,7 @@ mod macos {
     pub(super) const AARCH64: &str = "aarch64-apple-darwin";
     pub(super) const X86: &str = "x86_64-apple-darwin";
 
-    pub(super) fn detect_targets_macos() -> Vec<Box<str>> {
+    pub(super) fn detect_targets_macos() -> Vec<String> {
         if guess_host_triple() == Some(AARCH64) {
             vec![AARCH64.into(), X86.into()]
         } else {


### PR DESCRIPTION
Upgrade to Clap 3!

Also split off all the "overrides" options to their own section in the help. Looks like:

```
cargo-binstall 0.8.0
Install a Rust binary... from binaries!

USAGE:
    cargo-binstall [OPTIONS] <crate>

ARGS:
    <crate>    Package name for installation

OPTIONS:
        --dry-run              Dry run, fetch and show changes without installing binaries
    -h, --help                 Print help information
        --log-level <LEVEL>    Utility log level [default: info]
        --no-cleanup           Do not cleanup temporary files
        --no-confirm           Disable interactive mode / confirmation prompts
        --no-symlinks          Disable symlinking / versioned updates
        --version <VERSION>    Semver filter to select the package version to install [default: *]

OVERRIDES:
        --bin-dir <BIN_DIR>                Override Cargo.toml package manifest bin-dir
        --install-path <INSTALL_PATH>      Override install path for downloaded binary
        --manifest-path <MANIFEST_PATH>    Override manifest source
        --pkg-fmt <PKG_FMT>                Override Cargo.toml package manifest pkg-fmt
        --pkg-url <PKG_URL>                Override Cargo.toml package manifest pkg-url
        --targets <TRIPLE>                 Override binary target set
```

This also cleans up and completes the multi-targets functionality.