### PR TITLE
Support for checking multi-targets

### DIFF
--- a/src/fetchers.rs
+++ b/src/fetchers.rs
@@ -30,6 +30,9 @@ pub trait Fetcher {
 
     /// Should return true if the remote is from a third-party source
     fn is_third_party(&self) -> bool;
+
+    /// Return the target for this fetcher
+    fn target(&self) -> &str;
 }
 
 /// Data required to fetch a package

--- a/src/fetchers/gh_crate_meta.rs
+++ b/src/fetchers/gh_crate_meta.rs
@@ -66,6 +66,10 @@ impl super::Fetcher for GhCrateMeta {
     fn is_third_party(&self) -> bool {
         false
     }
+
+    fn target(&self) -> &str {
+        &self.data.target
+    }
 }
 
 /// Template for constructing download paths

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -13,6 +13,7 @@ const USER_AGENT: &str = concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VE
 
 pub struct QuickInstall {
     package: String,
+    target: String,
 }
 
 #[async_trait::async_trait]
@@ -20,9 +21,10 @@ impl super::Fetcher for QuickInstall {
     async fn new(data: &Data) -> Box<Self> {
         let crate_name = &data.name;
         let version = &data.version;
-        let target = &data.target;
+        let target = data.target.clone();
         Box::new(Self {
             package: format!("{crate_name}-{version}-{target}"),
+            target,
         })
     }
 
@@ -49,6 +51,10 @@ impl super::Fetcher for QuickInstall {
 
     fn is_third_party(&self) -> bool {
         true
+    }
+
+    fn target(&self) -> &str {
+        &self.target
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -217,18 +217,24 @@ async fn entry() -> Result<()> {
         .join(format!("pkg-{}.{}", opts.name, meta.pkg_fmt));
     debug!("Using temporary download path: {}", pkg_path.display());
 
-    let fetcher_data = Data {
-        name: package.name.clone(),
-        target: opts.target.clone(),
-        version: package.version.clone(),
-        repo: package.repository.clone(),
-        meta: meta.clone(),
-    };
+    let fetcher_data: Vec<_> = detect_targets()
+        .await
+        .into_iter()
+        .map(|target| Data {
+            name: package.name.clone(),
+            target: target.into(),
+            version: package.version.clone(),
+            repo: package.repository.clone(),
+            meta: meta.clone(),
+        })
+        .collect();
 
     // Try github releases, then quickinstall
     let mut fetchers = MultiFetcher::default();
-    fetchers.add(GhCrateMeta::new(&fetcher_data).await);
-    fetchers.add(QuickInstall::new(&fetcher_data).await);
+    for data in &fetcher_data {
+        fetchers.add(GhCrateMeta::new(data).await);
+        fetchers.add(QuickInstall::new(data).await);
+    }
 
     match fetchers.first_available().await {
         Some(fetcher) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,7 +341,7 @@ async fn install_from_package(
     // based on those found via Cargo.toml
     let bin_data = bins::Data {
         name: package.name.clone(),
-        target: opts.target.clone(),
+        target: fetcher.target().to_string(),
         version: package.version.clone(),
         repo: package.repository.clone(),
         meta,


### PR DESCRIPTION
This is a draft PR demonstrating how we can support checking for multiple targets, it seems to be much easier than I thought.

Due to #157 being pending, I decided to not touch cmdline parsing at all and let #157 decides how we should handle `--target` since now we supports multiple targets.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>