### PR TITLE
Feature/parallelize multi fetcher

### DIFF
--- a/src/fetchers.rs
+++ b/src/fetchers.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::Arc;
 
 pub use gh_crate_meta::*;
 pub use log::debug;
@@ -12,7 +13,7 @@ mod quickinstall;
 #[async_trait::async_trait]
 pub trait Fetcher {
     /// Create a new fetcher from some data
-    async fn new(data: &Data) -> Box<Self>
+    async fn new(data: &Data) -> Arc<Self>
     where
         Self: Sized;
 
@@ -44,11 +45,11 @@ pub struct Data {
 
 #[derive(Default)]
 pub struct MultiFetcher {
-    fetchers: Vec<Box<dyn Fetcher>>,
+    fetchers: Vec<Arc<dyn Fetcher>>,
 }
 
 impl MultiFetcher {
-    pub fn add(&mut self, fetcher: Box<dyn Fetcher>) {
+    pub fn add(&mut self, fetcher: Arc<dyn Fetcher>) {
         self.fetchers.push(fetcher);
     }
 

--- a/src/fetchers.rs
+++ b/src/fetchers.rs
@@ -11,7 +11,7 @@ mod gh_crate_meta;
 mod quickinstall;
 
 #[async_trait::async_trait]
-pub trait Fetcher {
+pub trait Fetcher: Send + Sync {
     /// Create a new fetcher from some data
     async fn new(data: &Data) -> Arc<Self>
     where

--- a/src/fetchers/gh_crate_meta.rs
+++ b/src/fetchers/gh_crate_meta.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::Arc;
 
 use log::{debug, info, warn};
 use reqwest::Method;
@@ -22,8 +23,8 @@ impl GhCrateMeta {
 
 #[async_trait::async_trait]
 impl super::Fetcher for GhCrateMeta {
-    async fn new(data: &Data) -> Box<Self> {
-        Box::new(Self { data: data.clone() })
+    async fn new(data: &Data) -> Arc<Self> {
+        Arc::new(Self { data: data.clone() })
     }
 
     async fn check(&self) -> Result<bool, BinstallError> {

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::Arc;
 
 use log::info;
 use reqwest::Method;
@@ -17,11 +18,11 @@ pub struct QuickInstall {
 
 #[async_trait::async_trait]
 impl super::Fetcher for QuickInstall {
-    async fn new(data: &Data) -> Box<Self> {
+    async fn new(data: &Data) -> Arc<Self> {
         let crate_name = &data.name;
         let version = &data.version;
         let target = &data.target;
-        Box::new(Self {
+        Arc::new(Self {
             package: format!("{crate_name}-{version}-{target}"),
         })
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,7 +234,7 @@ async fn entry() -> Result<()> {
         Some(fetcher) => {
             install_from_package(
                 binaries,
-                fetcher,
+                &*fetcher,
                 install_path,
                 meta,
                 opts,


### PR DESCRIPTION
Parallelize `MultiFetcher.first_available`: Using `tokio::spawn` to run them in parallel since we are using multithreading runtime.