### PR TITLE
Optimize `GhCrateMeta::check`: Avoid converting url to str

### DIFF
--- a/src/fetchers/gh_crate_meta.rs
+++ b/src/fetchers/gh_crate_meta.rs
@@ -36,7 +36,7 @@ impl super::Fetcher for GhCrateMeta {
         }
 
         info!("Checking for package at: '{url}'");
-        remote_exists(url.as_str(), Method::HEAD).await
+        remote_exists(url, Method::HEAD).await
     }
 
     async fn fetch(&self, dst: &Path) -> Result<(), BinstallError> {

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -30,7 +30,7 @@ impl super::Fetcher for QuickInstall {
         let url = self.package_url();
         self.report().await?;
         info!("Checking for package at: '{url}'");
-        remote_exists(&url, Method::HEAD).await
+        remote_exists(Url::parse(&url)?, Method::HEAD).await
     }
 
     async fn fetch(&self, dst: &Path) -> Result<(), BinstallError> {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -32,8 +32,7 @@ pub fn load_manifest_path<P: AsRef<Path>>(
     Ok(manifest)
 }
 
-pub async fn remote_exists(url: &str, method: Method) -> Result<bool, BinstallError> {
-    let url = Url::parse(url)?;
+pub async fn remote_exists(url: Url, method: Method) -> Result<bool, BinstallError> {
     let req = reqwest::Client::new()
         .request(method.clone(), url.clone())
         .send()


### PR DESCRIPTION
Only to convert it back to `Url` in `helpers::remote_exists`

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>