### PR TITLE
Spawn `entry()` in `main` to improve parallelism

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ impl Termination for MainExit {
             Self::JoinErr(err) => {
                 error!("Fatal error:");
                 eprintln!("{err:?}");
-                ExitCode::from(16)
+                ExitCode::from(17)
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,15 +120,13 @@ fn main() -> MainExit {
     let done = start.elapsed();
     debug!("run time: {done:?}");
 
-    result
-        .map(|res| {
-            res.map(|_| MainExit::Success(done)).unwrap_or_else(|err| {
-                err.downcast::<BinstallError>()
-                    .map(MainExit::Error)
-                    .unwrap_or_else(MainExit::Report)
-            })
+    result.map_or_else(MainExit::JoinErr, |res| {
+        res.map(|_| MainExit::Success(done)).unwrap_or_else(|err| {
+            err.downcast::<BinstallError>()
+                .map(MainExit::Error)
+                .unwrap_or_else(MainExit::Report)
         })
-        .unwrap_or_else(MainExit::JoinErr)
+    })
 }
 
 async fn entry() -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use miette::{miette, IntoDiagnostic, Result, WrapErr};
 use simplelog::{ColorChoice, ConfigBuilder, TermLogger, TerminalMode};
 use structopt::StructOpt;
 use tempfile::TempDir;
-use tokio::{process::Command, runtime::Runtime};
+use tokio::{process::Command, runtime::Runtime, task::JoinError};
 
 use cargo_binstall::{
     bins,
@@ -84,6 +84,7 @@ enum MainExit {
     Success(Duration),
     Error(BinstallError),
     Report(miette::Report),
+    JoinErr(JoinError),
 }
 
 impl Termination for MainExit {
@@ -99,6 +100,11 @@ impl Termination for MainExit {
                 eprintln!("{err:?}");
                 ExitCode::from(16)
             }
+            Self::JoinErr(err) => {
+                error!("Fatal error:");
+                eprintln!("{err:?}");
+                ExitCode::from(16)
+            }
         }
     }
 }
@@ -107,19 +113,22 @@ fn main() -> MainExit {
     let start = Instant::now();
 
     let rt = Runtime::new().unwrap();
-    let result = rt.block_on(entry());
+    let handle = rt.spawn(entry());
+    let result = rt.block_on(handle);
     drop(rt);
 
     let done = start.elapsed();
     debug!("run time: {done:?}");
 
     result
-        .map(|_| MainExit::Success(done))
-        .unwrap_or_else(|err| {
-            err.downcast::<BinstallError>()
-                .map(MainExit::Error)
-                .unwrap_or_else(MainExit::Report)
+        .map(|res| {
+            res.map(|_| MainExit::Success(done)).unwrap_or_else(|err| {
+                err.downcast::<BinstallError>()
+                    .map(MainExit::Error)
+                    .unwrap_or_else(MainExit::Report)
+            })
         })
+        .unwrap_or_else(MainExit::JoinErr)
 }
 
 async fn entry() -> Result<()> {


### PR DESCRIPTION
Using `rt.block_on`, the future returned by `entry()` can only be run on
the main thread.

Buf if we use `tokio::spawn`, then it can be run on any thread.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>