### PR TITLE
Optimize helpers download

### DIFF
--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use crates_io_api::AsyncClient;
 use log::debug;
 use semver::{Version, VersionReq};
+use url::Url;
 
 use crate::{helpers::*, BinstallError, PkgFmt};
 
@@ -103,7 +104,7 @@ pub async fn fetch_crate_cratesio(
     debug!("Fetching crate from: {crate_url}");
 
     // Download crate
-    download(&crate_url, &tgz_path).await?;
+    download(Url::parse(&crate_url)?, &tgz_path).await?;
 
     // Decompress downloaded tgz
     debug!("Decompressing crate archive");

--- a/src/fetchers/gh_crate_meta.rs
+++ b/src/fetchers/gh_crate_meta.rs
@@ -43,7 +43,7 @@ impl super::Fetcher for GhCrateMeta {
     async fn fetch(&self, dst: &Path) -> Result<(), BinstallError> {
         let url = self.url()?;
         info!("Downloading package from: '{url}'");
-        download(url.as_str(), dst).await
+        download(url, dst).await
     }
 
     fn pkg_fmt(&self) -> PkgFmt {

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -39,7 +39,7 @@ impl super::Fetcher for QuickInstall {
     async fn fetch(&self, dst: &Path) -> Result<(), BinstallError> {
         let url = self.package_url();
         info!("Downloading package from: '{url}'");
-        download(&url, &dst).await
+        download(Url::parse(&url)?, &dst).await
     }
 
     fn pkg_fmt(&self) -> PkgFmt {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -41,8 +41,7 @@ pub async fn remote_exists(url: Url, method: Method) -> Result<bool, BinstallErr
 }
 
 /// Download a file from the provided URL to the provided path
-pub async fn download<P: AsRef<Path>>(url: &str, path: P) -> Result<(), BinstallError> {
-    let url = Url::parse(url)?;
+pub async fn download<P: AsRef<Path>>(url: Url, path: P) -> Result<(), BinstallError> {
     debug!("Downloading from: '{url}'");
 
     let resp = reqwest::get(url.clone())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ mod test {
             &[Product {
                 name: Some("cargo-binstall".to_string()),
                 path: Some("src/main.rs".to_string()),
-                edition: Some(cargo_toml::Edition::E2018),
+                edition: Some(cargo_toml::Edition::E2021),
                 ..Default::default()
             },],
         );


### PR DESCRIPTION
[Modify helpers::download to accept Url for url](https://github.com/ryankurte/cargo-binstall/commit/d8624f90185260f4eb8fbdba1cb2bc4247d269ed)

In `GhCrateMeta::fetch`, it parses `&str` to `Url` and
then back to `&str`, then `helpers::download` parses it
yet again to `Url`.

This PR also fixes the unit test `test::parse_meta` in `lib.rs`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>