### PR TITLE
Feature/avoid oom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,7 @@ dependencies = [
  "log",
  "miette",
  "reqwest",
+ "scopeguard",
  "semver",
  "serde",
  "simplelog",
@@ -1176,6 +1177,12 @@ name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "dirs",
  "env_logger",
  "flate2",
+ "futures-util",
  "guess_host_triple",
  "log",
  "miette",
@@ -597,7 +598,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.3",
  "tracing",
 ]
 
@@ -1112,6 +1113,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-rustls",
+ "tokio-util 0.6.10",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1514,6 +1516,20 @@ dependencies = [
  "rustls",
  "tokio",
  "webpki",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1512,7 +1512,19 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ name = "cargo-binstall"
 version = "0.9.1"
 dependencies = [
  "async-trait",
+ "bytes",
  "cargo_metadata",
  "cargo_toml",
  "clap 3.1.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ clap = { version = "3.1.18", features = ["derive"] }
 crates_io_api = { version = "0.8.0", default-features = false, features = ["rustls"] }
 dirs = "4.0.0"
 flate2 = { version = "1.0.24", features = ["zlib-ng"], default-features = false }
+futures-util = { version = "0.3.21", default-features = false }
 log = "0.4.14"
 miette = { version = "4.7.1", features = ["fancy-no-backtrace"] }
 reqwest = { version = "0.11.10", features = [ "rustls-tls", "stream" ], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ futures-util = { version = "0.3.21", default-features = false }
 log = "0.4.14"
 miette = { version = "4.7.1", features = ["fancy-no-backtrace"] }
 reqwest = { version = "0.11.10", features = [ "rustls-tls", "stream" ], default-features = false }
+scopeguard = "1.1.0"
 semver = "1.0.7"
 serde = { version = "1.0.136", features = [ "derive" ] }
 simplelog = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tar = "0.4.38"
 tempfile = "3.3.0"
 thiserror = "1.0.31"
 tinytemplate = "1.2.1"
-tokio = { version = "1.19.1", features = [ "rt-multi-thread", "process" ], default-features = false }
+tokio = { version = "1.19.1", features = [ "rt-multi-thread", "process", "sync" ], default-features = false }
 url = "2.2.2"
 xz2 = "0.1.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tar = "0.4.38"
 tempfile = "3.3.0"
 thiserror = "1.0.31"
 tinytemplate = "1.2.1"
-tokio = { version = "1.19.1", features = [ "rt-multi-thread", "process", "sync" ], default-features = false }
+tokio = { version = "1.19.1", features = [ "rt-multi-thread", "process", "sync", "macros" ], default-features = false }
 url = "2.2.2"
 xz2 = "0.1.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ pkg-fmt = "zip"
 
 [dependencies]
 async-trait = "0.1.56"
+bytes = "1.1.0"
 cargo_metadata = "0.14.2"
 cargo_toml = "0.11.4"
 clap = { version = "3.1.18", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ dirs = "4.0.0"
 flate2 = { version = "1.0.24", features = ["zlib-ng"], default-features = false }
 log = "0.4.14"
 miette = { version = "4.7.1", features = ["fancy-no-backtrace"] }
-reqwest = { version = "0.11.10", features = [ "rustls-tls" ], default-features = false }
+reqwest = { version = "0.11.10", features = [ "rustls-tls", "stream" ], default-features = false }
 semver = "1.0.7"
 serde = { version = "1.0.136", features = [ "derive" ] }
 simplelog = "0.12.0"

--- a/src/fetchers.rs
+++ b/src/fetchers.rs
@@ -64,13 +64,13 @@ impl MultiFetcher {
             .map(|fetcher| {
                 (
                     fetcher.clone(),
-                    AutoAbortJoinHandle(tokio::spawn(async move { fetcher.check().await })),
+                    AutoAbortJoinHandle::new(tokio::spawn(async move { fetcher.check().await })),
                 )
             })
             .collect();
 
-        for (fetcher, mut handle) in handles {
-            match (&mut handle.0).await {
+        for (fetcher, handle) in handles {
+            match handle.await {
                 Ok(Ok(true)) => return Some(fetcher),
                 Ok(Ok(false)) => (),
                 Ok(Err(err)) => {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
     io::{self, stderr, stdin, Write},
+    ops::{Deref, DerefMut},
     path::{Path, PathBuf},
 };
 
@@ -309,5 +310,19 @@ pub struct AutoAbortJoinHandle<T>(pub task::JoinHandle<T>);
 impl<T> Drop for AutoAbortJoinHandle<T> {
     fn drop(&mut self) {
         self.0.abort();
+    }
+}
+
+impl<T> Deref for AutoAbortJoinHandle<T> {
+    type Target = task::JoinHandle<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for AutoAbortJoinHandle<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -300,3 +300,12 @@ impl AsyncFileWriter {
         }
     }
 }
+
+#[derive(Debug)]
+pub struct AutoAbortJoinHandle<T>(pub task::JoinHandle<T>);
+
+impl<T> Drop for AutoAbortJoinHandle<T> {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
+}


### PR DESCRIPTION
`helpers::download` currently downloads the entire file and stores it in memory before writing it to disk.
This has the side-effect of if the file is super large, then it might run out of memory and panic.

## TODO
 - Implementing `download_and_extract` that downloads and extracts without storing the intermediate steps on disk.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>