### PR TITLE
Fix/confirm

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -20,7 +20,7 @@ mod auto_abort_join_handle;
 pub use auto_abort_join_handle::AutoAbortJoinHandle;
 
 mod confirm;
-pub use confirm::{confirm, Confirmer};
+pub use confirm::Confirmer;
 
 mod extracter;
 mod readable_rx;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -20,7 +20,7 @@ mod auto_abort_join_handle;
 pub use auto_abort_join_handle::AutoAbortJoinHandle;
 
 mod confirm;
-pub use confirm::confirm;
+pub use confirm::{confirm, Confirmer};
 
 mod extracter;
 mod readable_rx;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -19,8 +19,8 @@ pub use async_extracter::extract_archive_stream;
 mod auto_abort_join_handle;
 pub use auto_abort_join_handle::AutoAbortJoinHandle;
 
-mod confirm;
-pub use confirm::Confirmer;
+mod ui_thread;
+pub use ui_thread::UIThread;
 
 mod extracter;
 mod readable_rx;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,10 +1,11 @@
 use std::{
+    borrow::Cow,
     io::{stderr, stdin, Write},
     path::{Path, PathBuf},
 };
 
 use cargo_toml::Manifest;
-use log::{debug, info};
+use log::debug;
 use reqwest::Method;
 use serde::Serialize;
 use tinytemplate::TinyTemplate;
@@ -17,6 +18,9 @@ pub use async_extracter::extract_archive_stream;
 
 mod auto_abort_join_handle;
 pub use auto_abort_join_handle::AutoAbortJoinHandle;
+
+mod confirm;
+pub use confirm::confirm;
 
 mod extracter;
 mod readable_rx;
@@ -127,23 +131,6 @@ pub fn get_install_path<P: AsRef<Path>>(install_path: Option<P>) -> Option<PathB
     }
 
     dir
-}
-
-pub fn confirm() -> Result<(), BinstallError> {
-    loop {
-        info!("Do you wish to continue? yes/[no]");
-        eprint!("? ");
-        stderr().flush().ok();
-
-        let mut input = String::new();
-        stdin().read_line(&mut input).unwrap();
-
-        match input.as_str().trim() {
-            "yes" | "y" | "YES" | "Y" => break Ok(()),
-            "no" | "n" | "NO" | "N" | "" => break Err(BinstallError::UserAbort),
-            _ => continue,
-        }
-    }
 }
 
 pub trait Template: Serialize {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,6 +1,4 @@
 use std::{
-    borrow::Cow,
-    io::{stderr, stdin, Write},
     path::{Path, PathBuf},
 };
 

--- a/src/helpers/confirm.rs
+++ b/src/helpers/confirm.rs
@@ -1,5 +1,8 @@
+use std::io::{self, BufRead, Write};
+
 use log::info;
-use std::io::{stderr, stdin, Write};
+use tokio::sync::mpsc;
+use tokio::task::spawn_blocking;
 
 use crate::BinstallError;
 
@@ -7,15 +10,108 @@ pub fn confirm() -> Result<(), BinstallError> {
     loop {
         info!("Do you wish to continue? yes/[no]");
         eprint!("? ");
-        stderr().flush().ok();
+        io::stderr().flush().ok();
 
         let mut input = String::new();
-        stdin().read_line(&mut input).unwrap();
+        io::stdin().read_line(&mut input).unwrap();
 
         match input.as_str().trim() {
             "yes" | "y" | "YES" | "Y" => break Ok(()),
             "no" | "n" | "NO" | "N" | "" => break Err(BinstallError::UserAbort),
             _ => continue,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ConfirmerInner {
+    /// Request for confirmation
+    request_tx: mpsc::Sender<()>,
+
+    /// Confirmation
+    confirm_rx: mpsc::Receiver<Result<(), BinstallError>>,
+}
+
+impl ConfirmerInner {
+    fn new() -> Self {
+        let (request_tx, mut request_rx) = mpsc::channel(1);
+        let (confirm_tx, confirm_rx) = mpsc::channel(10);
+
+        spawn_blocking(move || {
+            // This task should be the only one able to
+            // access stdin
+            let mut stdin = io::stdin().lock();
+            let mut input = String::with_capacity(16);
+
+            loop {
+                if request_rx.blocking_recv().is_none() {
+                    break;
+                }
+
+                // Lock stdout so that nobody can interfere
+                // with confirmation.
+                let mut stdout = io::stdout().lock();
+
+                let res = loop {
+                    writeln!(&mut stdout, "Do you wish to continue? yes/[no]").unwrap();
+                    write!(&mut stdout, "? ").unwrap();
+                    stdout.flush().unwrap();
+
+                    input.clear();
+                    if stdin.read_line(&mut input).is_err() {
+                        break Err(BinstallError::UserAbort);
+                    }
+
+                    match input.as_str().trim() {
+                        "yes" | "y" | "YES" | "Y" => break Ok(()),
+                        "no" | "n" | "NO" | "N" | "" => break Err(BinstallError::UserAbort),
+                        _ => continue,
+                    }
+                };
+
+                confirm_tx
+                    .blocking_send(res)
+                    .expect("entry exits when confirming request");
+            }
+        });
+
+        Self {
+            request_tx,
+            confirm_rx,
+        }
+    }
+
+    async fn confirm(&mut self) -> Result<(), BinstallError> {
+        self.request_tx
+            .send(())
+            .await
+            .map_err(|_| BinstallError::UserAbort)?;
+
+        self.confirm_rx
+            .recv()
+            .await
+            .unwrap_or(Err(BinstallError::UserAbort))
+    }
+}
+
+#[derive(Debug)]
+pub struct Confirmer(Option<ConfirmerInner>);
+
+impl Confirmer {
+    ///  * `enable` - `true` to enable confirmation, `false` to disable it.
+    pub fn new(enable: bool) -> Self {
+        Self(if enable {
+            Some(ConfirmerInner::new())
+        } else {
+            None
+        })
+    }
+
+    pub async fn confirm(&mut self) -> Result<(), BinstallError> {
+        if let Some(inner) = self.0.as_mut() {
+            inner.confirm().await
+        } else {
+            Ok(())
         }
     }
 }

--- a/src/helpers/confirm.rs
+++ b/src/helpers/confirm.rs
@@ -40,9 +40,7 @@ impl ConfirmerInner {
                     stdout.flush().unwrap();
 
                     input.clear();
-                    if stdin.read_line(&mut input).is_err() {
-                        break Err(BinstallError::UserAbort);
-                    }
+                    stdin.read_line(&mut input).unwrap();
 
                     match input.as_str().trim() {
                         "yes" | "y" | "YES" | "Y" => break Ok(()),

--- a/src/helpers/confirm.rs
+++ b/src/helpers/confirm.rs
@@ -1,27 +1,9 @@
 use std::io::{self, BufRead, Write};
 
-use log::info;
 use tokio::sync::mpsc;
 use tokio::task::spawn_blocking;
 
 use crate::BinstallError;
-
-pub fn confirm() -> Result<(), BinstallError> {
-    loop {
-        info!("Do you wish to continue? yes/[no]");
-        eprint!("? ");
-        io::stderr().flush().ok();
-
-        let mut input = String::new();
-        io::stdin().read_line(&mut input).unwrap();
-
-        match input.as_str().trim() {
-            "yes" | "y" | "YES" | "Y" => break Ok(()),
-            "no" | "n" | "NO" | "N" | "" => break Err(BinstallError::UserAbort),
-            _ => continue,
-        }
-    }
-}
 
 #[derive(Debug)]
 struct ConfirmerInner {

--- a/src/helpers/confirm.rs
+++ b/src/helpers/confirm.rs
@@ -1,0 +1,21 @@
+use log::info;
+use std::io::{stderr, stdin, Write};
+
+use crate::BinstallError;
+
+pub fn confirm() -> Result<(), BinstallError> {
+    loop {
+        info!("Do you wish to continue? yes/[no]");
+        eprint!("? ");
+        stderr().flush().ok();
+
+        let mut input = String::new();
+        stdin().read_line(&mut input).unwrap();
+
+        match input.as_str().trim() {
+            "yes" | "y" | "YES" | "Y" => break Ok(()),
+            "no" | "n" | "NO" | "N" | "" => break Err(BinstallError::UserAbort),
+            _ => continue,
+        }
+    }
+}

--- a/src/helpers/ui_thread.rs
+++ b/src/helpers/ui_thread.rs
@@ -6,7 +6,7 @@ use tokio::task::spawn_blocking;
 use crate::BinstallError;
 
 #[derive(Debug)]
-struct ConfirmerInner {
+struct UIThreadInner {
     /// Request for confirmation
     request_tx: mpsc::Sender<()>,
 
@@ -14,7 +14,7 @@ struct ConfirmerInner {
     confirm_rx: mpsc::Receiver<Result<(), BinstallError>>,
 }
 
-impl ConfirmerInner {
+impl UIThreadInner {
     fn new() -> Self {
         let (request_tx, mut request_rx) = mpsc::channel(1);
         let (confirm_tx, confirm_rx) = mpsc::channel(10);
@@ -75,13 +75,13 @@ impl ConfirmerInner {
 }
 
 #[derive(Debug)]
-pub struct Confirmer(Option<ConfirmerInner>);
+pub struct UIThread(Option<UIThreadInner>);
 
-impl Confirmer {
+impl UIThread {
     ///  * `enable` - `true` to enable confirmation, `false` to disable it.
     pub fn new(enable: bool) -> Self {
         Self(if enable {
-            Some(ConfirmerInner::new())
+            Some(UIThreadInner::new())
         } else {
             None
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,7 +191,7 @@ async fn entry() -> Result<()> {
     )
     .unwrap();
 
-    let mut confirmer = Confirmer::new(!opts.no_confirm);
+    let mut uithread = UIThread::new(!opts.no_confirm);
 
     // Compute install directory
     let install_path = get_install_path(opts.install_path.as_deref()).ok_or_else(|| {
@@ -231,7 +231,7 @@ async fn entry() -> Result<()> {
         );
 
         if !opts.dry_run {
-            confirmer.confirm().await?;
+            uithread.confirm().await?;
         }
     }
 
@@ -305,7 +305,7 @@ async fn entry() -> Result<()> {
                 opts,
                 package,
                 temp_dir,
-                &mut confirmer,
+                &mut uithread,
             )
             .await
         }
@@ -320,7 +320,7 @@ async fn entry() -> Result<()> {
                 .first()
                 .ok_or_else(|| miette!("No viable targets found, try with `--targets`"))?;
 
-            install_from_source(opts, package, target, &mut confirmer).await
+            install_from_source(opts, package, target, &mut uithread).await
         }
     }
 }
@@ -334,7 +334,7 @@ async fn install_from_package(
     opts: Options,
     package: Package<Meta>,
     temp_dir: TempDir,
-    confirmer: &mut Confirmer,
+    uithread: &mut UIThread,
 ) -> Result<()> {
     // Prompt user for third-party source
     if fetcher.is_third_party() {
@@ -343,7 +343,7 @@ async fn install_from_package(
             fetcher.source_name()
         );
         if !opts.dry_run {
-            confirmer.confirm().await?;
+            uithread.confirm().await?;
         }
     } else {
         info!(
@@ -433,7 +433,7 @@ async fn install_from_package(
         return Ok(());
     }
 
-    confirmer.confirm().await?;
+    uithread.confirm().await?;
 
     info!("Installing binaries...");
     for file in &bin_files {
@@ -462,12 +462,12 @@ async fn install_from_source(
     opts: Options,
     package: Package<Meta>,
     target: &str,
-    confirmer: &mut Confirmer,
+    uithread: &mut UIThread,
 ) -> Result<()> {
     // Prompt user for source install
     warn!("The package will be installed from source (with cargo)",);
     if !opts.dry_run {
-        confirmer.confirm().await?;
+        uithread.confirm().await?;
     }
 
     if opts.dry_run {


### PR DESCRIPTION
 - Perform all the blocking operations required for confirm in a tokio blocking thread.
 - Locks `stdin` and `stdout` to prevent interference when confirming.
 - Avoid mixing `info!` and `print!`.
 - Failure to write to `stdout` or read from `stdin` would be treated as `Err(BinstallError::UserAbort)` and `cargo-binstall` would exit gracefully.