### PR TITLE
Feature: Support https only mode and min tls version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
  "guess_host_triple",
  "log",
  "miette",
+ "once_cell",
  "reqwest",
  "scopeguard",
  "semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ flate2 = { version = "1.0.24", features = ["zlib-ng"], default-features = false 
 futures-util = { version = "0.3.21", default-features = false }
 log = "0.4.14"
 miette = { version = "4.7.1", features = ["fancy-no-backtrace"] }
+once_cell = "1.12.0"
 reqwest = { version = "0.11.11", features = [ "rustls-tls", "stream" ], default-features = false }
 scopeguard = "1.1.0"
 semver = "1.0.10"

--- a/ci-scripts/run_tests_unix.sh
+++ b/ci-scripts/run_tests_unix.sh
@@ -22,6 +22,11 @@ cargo binstall --help >/dev/null
 cargo binstall --help >/dev/null
 
 # Install binaries using https-only-mode and specify min tls ver
-"./$1" binstall --https-only-mode --min-tls-version tls1-3 cargo-binstall
+"./$1" binstall \
+    --log-level debug \
+    --https-only-mode \
+    --min-tls-version tls1-3 \
+    --no-confirm \
+    cargo-binstall
 # Test that the installed binaries can be run
 cargo binstall --help >/dev/null

--- a/ci-scripts/run_tests_unix.sh
+++ b/ci-scripts/run_tests_unix.sh
@@ -20,3 +20,8 @@ cargo binstall --help >/dev/null
 "./$1" binstall --log-level debug --manifest-path . --no-confirm cargo-binstall
 # Test that the installed binaries can be run
 cargo binstall --help >/dev/null
+
+# Install binaries using https-only-mode and specify min tls ver
+"./$1" binstall --https-only-mode --min-tls-version tls1-3 cargo-binstall
+# Test that the installed binaries can be run
+cargo binstall --help >/dev/null

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -7,7 +7,9 @@ use tokio::task::JoinHandle;
 use url::Url;
 
 use super::Data;
-use crate::{download_and_extract, remote_exists, BinstallError, PkgFmt};
+use crate::{
+    download_and_extract, new_reqwest_client_builder, remote_exists, BinstallError, PkgFmt,
+};
 
 const BASE_URL: &str = "https://github.com/alsuren/cargo-quickinstall/releases/download";
 const STATS_URL: &str = "https://warehouse-clerk-tmp.vercel.app/api/crate";
@@ -89,7 +91,7 @@ impl QuickInstall {
             let url = Url::parse(&stats_url)?;
             debug!("Sending installation report to quickinstall ({url})");
 
-            reqwest::Client::builder()
+            new_reqwest_client_builder()
                 .user_agent(USER_AGENT)
                 .build()?
                 .request(Method::HEAD, url.clone())

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -51,9 +51,7 @@ pub fn new_reqwest_client_builder() -> ClientBuilder {
     let mut builder = ClientBuilder::new();
 
     if let Some((https_only, min_tls_ver_opt)) = REQWESTGLOBALCONFIG.get() {
-        if *https_only {
-            builder = builder.http2_prior_knowledge();
-        }
+        builder = builder.https_only(*https_only);
 
         if let Some(min_tls_ver) = *min_tls_ver_opt {
             builder = builder.min_tls_version(min_tls_ver.into());

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -27,6 +27,9 @@ mod stream_readable;
 mod path_ext;
 pub use path_ext::*;
 
+mod tls_version;
+pub use tls_version::TLSVersion;
+
 /// Load binstall metadata from the crate `Cargo.toml` at the provided path
 pub fn load_manifest_path<P: AsRef<Path>>(
     manifest_path: P,

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -53,6 +53,10 @@ pub fn new_reqwest_client_builder() -> ClientBuilder {
     if let Some((https_only, min_tls_ver_opt)) = REQWESTGLOBALCONFIG.get() {
         builder = builder.https_only(*https_only);
 
+        if *https_only {
+            builder = builder.min_tls_version(reqwest::tls::Version::TLS_1_2);
+        }
+
         if let Some(min_tls_ver) = *min_tls_ver_opt {
             builder = builder.min_tls_version(min_tls_ver.into());
         }

--- a/src/helpers/tls_version.rs
+++ b/src/helpers/tls_version.rs
@@ -1,0 +1,17 @@
+use clap::ArgEnum;
+use reqwest::tls::Version;
+
+#[derive(Debug, Copy, Clone, ArgEnum)]
+pub enum TLSVersion {
+    Tls1_2,
+    Tls1_3,
+}
+
+impl From<TLSVersion> for Version {
+    fn from(ver: TLSVersion) -> Self {
+        match ver {
+            TLSVersion::Tls1_2 => Version::TLS_1_2,
+            TLSVersion::Tls1_3 => Version::TLS_1_3,
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,10 @@ struct Options {
     #[clap(long)]
     no_cleanup: bool,
 
-    /// Enable https only mode
+    /// Enable https only mode.
+    ///
+    /// When https only mode is enabled, it will also set
+    /// minimum TLS version to tls1_2.
     #[clap(long)]
     https_only_mode: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,6 +84,14 @@ struct Options {
     #[clap(long)]
     no_cleanup: bool,
 
+    /// Enable https only mode
+    #[clap(long)]
+    https_only_mode: bool,
+
+    /// Decide which TLS version to use.
+    #[clap(long, arg_enum)]
+    min_tls_version: Option<TLSVersion>,
+
     /// Override manifest source.
     ///
     /// This skips searching crates.io for a manifest and uses the specified path directly, useful

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,6 +185,11 @@ async fn entry() -> Result<()> {
         bin_dir: opts.bin_dir.take(),
     };
 
+    // Initialize REQWESTGLOBALCONFIG
+    REQWESTGLOBALCONFIG
+        .set((opts.https_only_mode, opts.min_tls_version))
+        .unwrap();
+
     // Setup logging
     let mut log_config = ConfigBuilder::new();
     log_config.add_filter_ignore("hyper".to_string());


### PR DESCRIPTION
This PR adds new command line option:
 - `--https-only-mode`
 - `--min-tls-version [tls1-2, tls1-3]`

I added this since [taiki-e/install-action] requires https only and tls to be at least `1.2`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>

[taiki-e/install-action]: https://github.com/taiki-e/install-action