### PR TITLE
feature:  Detect `*-pc-windows-gnu` targets in `targets.rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ zip = { version = "0.6.2", default-features = false, features = [ "deflate", "bz
 # Enable feature zstdmt to enable multithreading in libzstd.
 zstd = { version = "0.10.0", features = [ "bindgen", "zstdmt" ], default-features = false }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
 guess_host_triple = "0.1.3"
 
 [dev-dependencies]

--- a/src/target.rs
+++ b/src/target.rs
@@ -32,6 +32,11 @@ pub async fn detect_targets() -> Vec<String> {
             v.push(macos::X86.into());
         }
 
+        #[cfg(target_os = "windows")]
+        if v[0].contains("gnu") {
+            v.push(v[0].replace("gnu", "msvc"));
+        }
+
         v
     } else {
         #[cfg(target_os = "linux")]
@@ -42,7 +47,11 @@ pub async fn detect_targets() -> Vec<String> {
         {
             macos::detect_targets_macos()
         }
-        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        #[cfg(target_os = "windows")]
+        {
+            windows::detect_targets_windows()
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
         {
             vec![TARGET.into()]
         }
@@ -143,5 +152,21 @@ mod macos {
         } else {
             vec![X86.into()]
         }
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod windows {
+    use super::TARGET;
+    use guess_host_triple::guess_host_triple;
+
+    pub(super) fn detect_targets_windows() -> Vec<String> {
+        let mut targets = vec![guess_host_triple().unwrap_or(TARGET).to_string()];
+
+        if targets[0].contains("gnu") {
+            targets.push(targets[0].replace("gnu", "msvc"));
+        }
+
+        targets
     }
 }


### PR DESCRIPTION
And add fallback `*-pc-windows-msvc` to the returned targets.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>