### PR TITLE
Run blocking fs operations & parsing in `block_in_place` mode

### DIFF
--- a/src/drivers/crates_io.rs
+++ b/src/drivers/crates_io.rs
@@ -71,6 +71,5 @@ pub async fn fetch_crate_cratesio(
         TarBasedFmt::Tgz,
         ManifestVisitor::new(manifest_dir_path),
     )
-    .await?
-    .load_manifest()
+    .await
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -9,6 +9,7 @@ use once_cell::sync::OnceCell;
 use reqwest::{Client, ClientBuilder, Method, Response};
 use serde::Serialize;
 use tinytemplate::TinyTemplate;
+use tokio::task::block_in_place;
 use url::Url;
 
 use crate::{BinstallError, Meta, PkgFmt, PkgFmtDecomposed, TarBasedFmt};
@@ -38,13 +39,15 @@ pub static REQWESTGLOBALCONFIG: OnceCell<(bool, Option<TLSVersion>)> = OnceCell:
 pub fn load_manifest_path<P: AsRef<Path>>(
     manifest_path: P,
 ) -> Result<Manifest<Meta>, BinstallError> {
-    debug!("Reading manifest: {}", manifest_path.as_ref().display());
+    block_in_place(|| {
+        debug!("Reading manifest: {}", manifest_path.as_ref().display());
 
-    // Load and parse manifest (this checks file system for binary output names)
-    let manifest = Manifest::<Meta>::from_path_with_metadata(manifest_path)?;
+        // Load and parse manifest (this checks file system for binary output names)
+        let manifest = Manifest::<Meta>::from_path_with_metadata(manifest_path)?;
 
-    // Return metadata
-    Ok(manifest)
+        // Return metadata
+        Ok(manifest)
+    })
 }
 
 pub fn new_reqwest_client_builder() -> ClientBuilder {

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -130,16 +130,16 @@ pub async fn download_tar_based_and_visit<V: TarEntriesVisitor + Debug + Send + 
     url: Url,
     fmt: TarBasedFmt,
     visitor: V,
-) -> Result<V, BinstallError> {
+) -> Result<V::Target, BinstallError> {
     let stream = create_request(url).await?;
 
     debug!("Downloading and extracting then in-memory processing");
 
-    let visitor = extract_tar_based_stream_and_visit(stream, fmt, visitor).await?;
+    let ret = extract_tar_based_stream_and_visit(stream, fmt, visitor).await?;
 
     debug!("Download, extraction and in-memory procession OK");
 
-    Ok(visitor)
+    Ok(ret)
 }
 
 /// Fetch install path from environment


### PR DESCRIPTION
The following steps are moved into `block_in_place` mode:
 - `main.rs:448`: "Install binaries"
 - `load_manifest_path`: which performs file reading and `std::fs::read_dir`
 - `ManifestVisitor`: the parsing of `Manifest<Meta>` is moved into `block_in_place` mode.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>