### PR TITLE
feature: Install binaries atomically

### DIFF
--- a/src/bins.rs
+++ b/src/bins.rs
@@ -86,13 +86,6 @@ impl BinFile {
         );
         atomic_install(&self.source, &self.dest)?;
 
-        #[cfg(target_family = "unix")]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            debug!("Set permissions 755 on '{}'", self.dest.display());
-            std::fs::set_permissions(&self.dest, std::fs::Permissions::from_mode(0o755))?;
-        }
-
         Ok(())
     }
 

--- a/src/bins.rs
+++ b/src/bins.rs
@@ -4,7 +4,7 @@ use cargo_toml::Product;
 use log::debug;
 use serde::Serialize;
 
-use crate::{atomic_install, BinstallError, PkgFmt, PkgMeta, Template};
+use crate::{atomic_install, atomic_symlink_file, BinstallError, PkgFmt, PkgMeta, Template};
 
 pub struct BinFile {
     pub base_name: String,
@@ -103,10 +103,7 @@ impl BinFile {
             self.link.display(),
             dest.display()
         );
-        #[cfg(target_family = "unix")]
-        std::os::unix::fs::symlink(dest, &self.link)?;
-        #[cfg(target_family = "windows")]
-        std::os::windows::fs::symlink_file(dest, &self.link)?;
+        atomic_symlink_file(dest, &self.link)?;
 
         Ok(())
     }

--- a/src/bins.rs
+++ b/src/bins.rs
@@ -4,7 +4,7 @@ use cargo_toml::Product;
 use log::debug;
 use serde::Serialize;
 
-use crate::{BinstallError, PkgFmt, PkgMeta, Template};
+use crate::{atomic_install, BinstallError, PkgFmt, PkgMeta, Template};
 
 pub struct BinFile {
     pub base_name: String,
@@ -80,11 +80,11 @@ impl BinFile {
     pub fn install_bin(&self) -> Result<(), BinstallError> {
         // TODO: check if file already exists
         debug!(
-            "Copy file from '{}' to '{}'",
+            "Atomically install file from '{}' to '{}'",
             self.source.display(),
             self.dest.display()
         );
-        std::fs::copy(&self.source, &self.dest)?;
+        atomic_install(&self.source, &self.dest)?;
 
         #[cfg(target_family = "unix")]
         {

--- a/src/bins.rs
+++ b/src/bins.rs
@@ -109,12 +109,9 @@ impl BinFile {
     }
 
     fn link_dest(&self) -> &Path {
-        #[cfg(target_family = "unix")]
-        {
+        if cfg!(target_family = "unix") {
             Path::new(self.dest.file_name().unwrap())
-        }
-        #[cfg(target_family = "windows")]
-        {
+        } else {
             &self.dest
         }
     }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -211,6 +211,15 @@ pub fn atomic_install(src: &Path, dst: &Path) -> io::Result<()> {
         );
         io::copy(&mut src_file, tempfile.as_file_mut())?;
 
+        debug!("Retrieving permissions of '{}'", src.display());
+        let permissions = src_file.metadata()?.permissions();
+
+        debug!(
+            "Setting permissions of '{}' to '{permissions:#?}'",
+            tempfile.path().display()
+        );
+        tempfile.as_file().set_permissions(permissions)?;
+
         debug!(
             "Persisting '{}' to '{}'",
             tempfile.path().display(),


### PR DESCRIPTION
This PR added a new function `helpers::atomic_install` and used it in `bins::BinFile::install_bin`.

`helpers::atomic_install` first attempts to use `rename` to atomically install the file.
When `rename` fails, it will switch to the fallback, which uses `tempfile::NamedTempFile` to create a named temporary file at the parent of `dst`, `std::io::copy` the `src` into the tempfile, then persist the named tempfile to `dst` atomically.

It also added a new function `helpers::atomic_symlink_file` and used it in `bins::BinFile::install_link`.

It creates a `tempfile::TempPath`, create a symlink with the `TempPath` as the linkname, then persist it to `link`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>