### PR TITLE
Set `opt-level` for release to `s`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ guess_host_triple = "0.1.3"
 env_logger = "0.9.0"
 
 [profile.release]
+opt-level = "s"
 lto = true
 codegen-units = 1
 panic = "abort"


### PR DESCRIPTION
O3 mostly enables float optimization, more aggressive loop unrolling and
function inline.

O2 is probably OK, but I want to reduce the binary size a bit by using
opt level "s".

Edit:

The CI shows that the binary size sees a significant reduction for all targets, but does not have much impact on the performance of the binary.

It's likely that the bottleneck is the network and IO.

Also, if this is found to be a problem later, we can always [override the profile](https://doc.rust-lang.org/cargo/reference/profiles.html#overrides) for the crates that matters, e.g. `zip`, `tar`, `bytes`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>