### PR TITLE
Use `opt-level = "z"` for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ mimalloc = ["dep:mimalloc"]
 env_logger = "0.9.0"
 
 [profile.release]
-opt-level = "s"
+opt-level = "z"
 lto = true
 codegen-units = 1
 panic = "abort"


### PR DESCRIPTION
On M1 MacOS Darwin 21.5, this produces binary that is 0.3M smaller while
taking 10s less to build.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>