### PR TITLE
Releng improvements

### DIFF
--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -144,9 +144,9 @@ jobs:
 
           target=$(basename "$o" | cut -d. -f1)
           if grep -qE '(apple|windows)' <<< "$target"; then
-            zip "../cargo-binstall-${target}.zip" *
+            zip -9 "../cargo-binstall-${target}.zip" *
           else
-            tar cvf "../cargo-binstall-${target}.tgz" *
+            tar cv * | gzip -9 > "../cargo-binstall-${target}.tgz"
           fi
 
           popd

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -142,7 +142,7 @@ jobs:
 
           cp ../../LICENSE.txt ../../README.md .
 
-          target=$(cut -d. -f1 <<< "$o")
+          target=$(basename "$o" | cut -d. -f1)
           if grep -qE '(apple|windows)' <<< "$target"; then
             zip "../cargo-binstall-${target}.zip" *
           else
@@ -181,7 +181,7 @@ jobs:
 
           cp ../../LICENSE.txt ../../README.md .
 
-          target=$(cut -d. -f1 <<< "$o")
+          target=$(basename "$o" | cut -d. -f1)
           if grep -qE '(apple|windows)' <<< "$target"; then
             zip "../cargo-binstall-${target}.zip" *
           else

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -122,44 +122,6 @@ jobs:
         name: "${{ matrix.target }}.${{ matrix.output }}"
         path: "${{ matrix.output }}"
 
-  release-test:
-    name: Package and release (testing)
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Get outputs
-      uses: actions/download-artifact@v3
-      with:
-        path: outputs/
-
-    - name: Create archives
-      shell: bash
-      run: |
-        set -euxo pipefail
-        for o in outputs/*; do
-          pushd "$o"
-
-          cp ../../LICENSE.txt ../../README.md .
-
-          target=$(basename "$o" | cut -d. -f1)
-          if grep -qE '(apple|windows)' <<< "$target"; then
-            zip -9 "../cargo-binstall-${target}.zip" *
-          else
-            tar cv * | gzip -9 > "../cargo-binstall-${target}.tgz"
-          fi
-
-          popd
-        done
-    - name: Upload output
-      uses: actions/upload-artifact@v3
-      with:
-        retention-days: 1
-        name: release-bits
-        path: |
-          outputs/cargo-binstall-*.zip
-          outputs/cargo-binstall-*.tgz
-
   release:
     name: Package and release
     needs: build

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -200,7 +200,7 @@ jobs:
         release_commit: ${{ github.event.head_commit.message }}
       run: |
         set -euxo pipefail
-        release_pr=$(head -n1 <<< "${release_commit:-}" | grep -oP '(?<=[(]#)\d+(?=[)])')
+        release_pr=$(head -n1 <<< "${release_commit:-}" | jq -Rr 'split("[()]"; "")[1] // ""')
         if [[ -z "$release_pr" ]]; then
           echo "::set-output name=notes_json::null"
           exit

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -174,15 +174,15 @@ jobs:
           --json body \
           --jq '"::set-output name=notes_json::\((.body | split("### Release notes")[1] // "") | tojson)"'
 
-      - name: Publish release
-        uses: softprops/action-gh-release@50195ba7f6f93d1ac97ba8332a178e008ad176aa
-        with:
-          tag_name: ${{ github.ref }}
-          name: ${{ github.ref }}
-          body: ${{ fromJSON(steps.notes.outputs.notes_json) }}
-          append_body: true
-          files: |
-            outputs/cargo-binstall-*.zip
-            outputs/cargo-binstall-*.tgz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Publish release
+      uses: softprops/action-gh-release@50195ba7f6f93d1ac97ba8332a178e008ad176aa
+      with:
+        tag_name: ${{ github.ref }}
+        name: ${{ github.ref }}
+        body: ${{ fromJSON(steps.notes.outputs.notes_json) }}
+        append_body: true
+        files: |
+          outputs/cargo-binstall-*.zip
+          outputs/cargo-binstall-*.tgz
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -13,7 +13,6 @@ env:
 jobs:
   build:
     name: Build and Test
-    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
@@ -22,45 +21,39 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             output: cargo-binstall
-            archive: tgz
             use-cross: false
             test: true
           - target: x86_64-apple-darwin
             os: macos-latest
             output: cargo-binstall
-            archive: zip
             use-cross: false
             test: true
           - target: aarch64-apple-darwin
             os: macos-latest
             output: cargo-binstall
-            archive: zip
             use-cross: false
             test: false
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             output: cargo-binstall.exe
-            archive: zip
             use-cross: false
             test: false
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             output: cargo-binstall
-            archive: tgz
             use-cross: false
             test: true
           - target: armv7-unknown-linux-musleabihf
             os: ubuntu-20.04
             output: cargo-binstall
-            archive: tgz
             use-cross: true
             test: false
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             output: cargo-binstall
-            archive: tgz
             use-cross: true
             test: false
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v2
@@ -122,30 +115,74 @@ jobs:
         ./${{ matrix.output }} binstall --manifest-path . --no-confirm cargo-binstall
         cargo binstall --help
 
-    - name: Create archive (tgz, linux)
-      if: ${{ matrix.os != 'macos-latest' && matrix.os != 'windows-latest' }}
-      run: tar -czvf cargo-binstall-${{ matrix.target }}.tgz ${{ matrix.output }}
-
-    - name: Create archive (zip, windows)
-      if: ${{ matrix.os == 'windows-latest' }}
-      run: tar.exe -a -c -f cargo-binstall-${{ matrix.target }}.zip ${{ matrix.output }}
-
-    - name: Create archive (zip, macos)
-      if: ${{ matrix.os == 'macos-latest' }}
-      run: zip cargo-binstall-${{ matrix.target }}.zip ${{ matrix.output }}
-
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v1
+    - name: Upload output
+      uses: actions/upload-artifact@v3
       with:
-        name: cargo-binstall-${{ matrix.target }}.${{ matrix.archive }}
-        path: cargo-binstall-${{ matrix.target }}.${{ matrix.archive }}
+        retention-days: 1
+        name: "${{ matrix.target }}.${{ matrix.output }}"
+        path: "${{ matrix.output }}"
 
-    - name: Upload binary to release
-      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-      uses: svenstaro/upload-release-action@v2
+  release:
+    name: Package and release
+    needs: build
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get outputs
+      uses: actions/download-artifact@v3
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: cargo-binstall-${{ matrix.target }}.${{ matrix.archive }}
-        asset_name: cargo-binstall-${{ matrix.target }}.${{ matrix.archive }}
-        tag: ${{ github.ref }}
-        overwrite: true
+        path: outputs/
+
+    - name: Create archives
+      shell: bash
+      run: |
+        set -euxo pipefail
+        for o in outputs/*; do
+          pushd "$o"
+
+          cp ../../LICENSE.txt ../../README.md .
+
+          target="$(cut -d. -f1 <<< "$o")
+          if grep -qE '(apple|windows)' <<< "$target"; then
+            zip "../../cargo-binstall-${target}.zip" *
+          else
+            tar cvf "../../cargo-binstall-${target}.tgz" *
+          fi
+
+          popd
+        done
+
+    - name: Extract release notes
+      id: notes
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_REPO: ${{ github.repository }}
+        release_commit: ${{ github.event.head_commit.message }}
+      run: |
+        set -euxo pipefail
+        release_pr=$(head -n1 <<< "${release_commit:-}" | grep -oP '(?<=[(]#)\d+(?=[)])')
+        if [[ -z "$release_pr" ]]; then
+          echo "::set-output name=notes_json::null"
+          exit
+        fi
+
+        gh \
+          pr --repo "$GITHUB_REPO" \
+          view "$release_pr" \
+          --json body \
+          --jq '"::set-output name=notes_json::\((.body | split("### Release notes")[1] // "") | tojson)"'
+
+      - name: Publish release
+        uses: softprops/action-gh-release@50195ba7f6f93d1ac97ba8332a178e008ad176aa
+        with:
+          tag_name: ${{ github.ref }}
+          name: ${{ github.ref }}
+          body: ${{ fromJSON(steps.notes.outputs.notes_json) }}
+          append_body: true
+          files: |
+            outputs/cargo-binstall-*.zip
+            outputs/cargo-binstall-*.tgz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -142,7 +142,7 @@ jobs:
 
           cp ../../LICENSE.txt ../../README.md .
 
-          target="$(cut -d. -f1 <<< "$o")
+          target=$(cut -d. -f1 <<< "$o")
           if grep -qE '(apple|windows)' <<< "$target"; then
             zip "../cargo-binstall-${target}.zip" *
           else
@@ -181,7 +181,7 @@ jobs:
 
           cp ../../LICENSE.txt ../../README.md .
 
-          target="$(cut -d. -f1 <<< "$o")
+          target=$(cut -d. -f1 <<< "$o")
           if grep -qE '(apple|windows)' <<< "$target"; then
             zip "../cargo-binstall-${target}.zip" *
           else

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -122,6 +122,44 @@ jobs:
         name: "${{ matrix.target }}.${{ matrix.output }}"
         path: "${{ matrix.output }}"
 
+  release-test:
+    name: Package and release (testing)
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get outputs
+      uses: actions/download-artifact@v3
+      with:
+        path: outputs/
+
+    - name: Create archives
+      shell: bash
+      run: |
+        set -euxo pipefail
+        for o in outputs/*; do
+          pushd "$o"
+
+          cp ../../LICENSE.txt ../../README.md .
+
+          target="$(cut -d. -f1 <<< "$o")
+          if grep -qE '(apple|windows)' <<< "$target"; then
+            zip "../cargo-binstall-${target}.zip" *
+          else
+            tar cvf "../cargo-binstall-${target}.tgz" *
+          fi
+
+          popd
+        done
+    - name: Upload output
+      uses: actions/upload-artifact@v3
+      with:
+        retention-days: 1
+        name: release-bits
+        path: |
+          outputs/cargo-binstall-*.zip
+          outputs/cargo-binstall-*.tgz
+
   release:
     name: Package and release
     needs: build
@@ -145,9 +183,9 @@ jobs:
 
           target="$(cut -d. -f1 <<< "$o")
           if grep -qE '(apple|windows)' <<< "$target"; then
-            zip "../../cargo-binstall-${target}.zip" *
+            zip "../cargo-binstall-${target}.zip" *
           else
-            tar cvf "../../cargo-binstall-${target}.tgz" *
+            tar cvf "../cargo-binstall-${target}.tgz" *
           fi
 
           popd

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -63,7 +63,7 @@ jobs:
 
           title="release: v${{ inputs.version }}"
           body_intro="This is a release PR for version **${{ inputs.version }}**."
-          body_merge="Upon merging, this will automatically build the CLI and create a GitHub release. You still need to manually publish the cargo crate."
+          body_merge="**Use squash merge.** Upon merging, this will automatically build the CLI and create a GitHub release. You still need to manually publish the cargo crate."
           body_pub="${fence}$ cd ${{ env.crate_path }}${nl}$ cargo publish${ecnef}"
           body_notes="---${br}_Edit release notes into the section below:_${br}<!-- do not change or remove this heading -->${nl}### Release notes"
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -1,0 +1,75 @@
+name: Open a release PR
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release
+        required: true
+        type: string
+
+jobs:
+  make-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install cargo-release
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-release
+          version: "0.21"
+
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+
+      - name: Extract info
+        run: |
+          set -euxo pipefail
+
+          branch_name="release-${{ inputs.version }}"
+          echo "branch_name=${branch_name}" >> $GITHUB_ENV
+
+      - name: Make release branch
+        run: git switch -c "${{ env.branch_name }}"
+
+      - name: Do release
+        run: |
+          set -euxo pipefail
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          cargo release \
+            --execute \
+            --no-push \
+            --no-tag \
+            --no-publish \
+            --no-confirm \
+            --verbose \
+            --config release.toml \
+            --allow-branch "${{ env.branch_name }}" \
+            --dependent-version upgrade \
+            "${{ inputs.version }}"
+
+      - name: Push new branch
+        run: |
+          set -euxo pipefail
+          git push origin "${{ env.branch_name }}"
+
+      - name: Create PR
+        run: |
+          set -euxo pipefail
+
+          nl=$'\n'
+          br=$'\n\n'
+          fence=$'```\n'
+          ecnef=$'\n```'
+
+          title="release: v${{ inputs.version }}"
+          body_intro="This is a release PR for version **${{ inputs.version }}**."
+          body_merge="Upon merging, this will automatically build the CLI and create a GitHub release. You still need to manually publish the cargo crate."
+          body_pub="${fence}$ cd ${{ env.crate_path }}${nl}$ cargo publish${ecnef}"
+          body_notes="---${br}_Edit release notes into the section below:_${br}<!-- do not change or remove this heading -->${nl}### Release notes"
+
+          body="${body_intro}${br}${body_merge}${br}${body_pub}${br}${body_notes}${br}"
+
+          gh pr create --title "$title" --body "$body" --base main --head "${{ env.branch_name }}" --label "release"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -12,10 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install cargo-release
-        uses: baptiste0928/cargo-install@v1
+        uses: taiki-e/install-action@v1
         with:
-          crate: cargo-release
-          version: "0.21"
+          tool: cargo-release
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,32 @@
+name: Tag a release
+on:
+  push:
+    branches:
+      - main
+    tags-ignore:
+      - "*"
+
+jobs:
+  make-tag:
+    runs-on: ubuntu-latest
+    # the commit message will look like: `release: v{version} (#{pr-number})`
+    if: "startsWith(github.event.head_commit.message, 'release: v')"
+    steps:
+      - name: Extract tag from commit message
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          set -euxo pipefail
+
+          message="$(head -n1 <<< "$COMMIT_MESSAGE")"
+          version="$(cut -d ' ' -f 2 <<< "${message}")"
+          echo "CUSTOM_TAG=${version}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v2
+      - name: Push release tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ env.CUSTOM_TAG }}
+          tag_prefix: ''

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,11 +72,11 @@ guess_host_triple = "0.1.3"
 default = []
 mimalloc = ["dep:mimalloc"]
 
-[build-dependencies]
-embed-resource = "1.6.1"
-
 [dev-dependencies]
 env_logger = "0.9.0"
+
+[build-dependencies]
+embed-resource = "1.6.1"
 
 [profile.release]
 opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,9 @@ guess_host_triple = "0.1.3"
 default = []
 mimalloc = ["dep:mimalloc"]
 
+[build-dependencies]
+embed-resource = "1.6.1"
+
 [dev-dependencies]
 env_logger = "0.9.0"
 

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,7 @@
-// Fetch build target and define this for the compiler
 fn main() {
+    embed_resource::compile("manifest.rc");
+
+    // Fetch build target and define this for the compiler
     println!(
         "cargo:rustc-env=TARGET={}",
         std::env::var("TARGET").unwrap()

--- a/manifest.rc
+++ b/manifest.rc
@@ -1,0 +1,2 @@
+#define RT_MANIFEST 24
+1 RT_MANIFEST "windows.manifest"

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,16 @@
+pre-release-commit-message = "release: v{{version}}"
+tag-prefix = "cli-"
+tag-message = "cargo-binstall {{version}}"
+
+# We wait until the release CI is done before publishing,
+# because publishing is irreversible, but a release can be
+# reverted a lot more easily.
+publish = false
+
+[[pre-release-replacements]]
+file = "cargo-binstall.exe.manifest"
+search = "^		version=\"[\\d.]+[.]0\""
+replace = "		version=\"{{version}}.0\""
+prerelease = false
+max = 1
+

--- a/release.toml
+++ b/release.toml
@@ -8,7 +8,7 @@ tag-message = "cargo-binstall {{version}}"
 publish = false
 
 [[pre-release-replacements]]
-file = "cargo-binstall.exe.manifest"
+file = "windows.manifest"
 search = "^		version=\"[\\d.]+[.]0\""
 replace = "		version=\"{{version}}.0\""
 prerelease = false

--- a/windows.manifest
+++ b/windows.manifest
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+	<assemblyIdentity
+		type="win32"
+		name="Binstall.Cli.binstall"
+		version="0.10.0.0"
+	/>
+
+	<trustInfo>
+		<security>
+			<!--
+			UAC settings:
+			- app should run at same integrity level as calling process
+			- app does not need to manipulate windows belonging to
+			higher-integrity-level processes
+			-->
+			<requestedPrivileges>
+				<requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+			</requestedPrivileges>
+		</security>
+	</trustInfo>
+
+	<compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+		<application>
+			<!-- Windows 10, 11 -->
+			<supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+			<!-- Windows 8.1 -->
+			<supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+			<!-- Windows 8 -->
+			<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+		</application>
+	</compatibility>
+
+	<application xmlns="urn:schemas-microsoft-com:asm.v3">
+		<windowsSettings xmlns:ws="http://schemas.microsoft.com/SMI/2020/WindowsSettings">
+			<ws:longPathAware xmlns:ws="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</ws:longPathAware>
+			<ws:activeCodePage xmlns:ws="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</ws:activeCodePage>
+			<ws:heapType xmlns:ws="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</ws:heapType>
+		</windowsSettings>
+	</application>
+</assembly>


### PR DESCRIPTION
This introduces the concept of a release PR:
- adds manual trigger on the Release PR github action
- it bumps the version numbers and does replacements via cargo-release
- it then pushes the result to a new branch and opens a PR with instructions to make a release
- merging the PR (with squash) triggers more github actions to:
  1. create a tag on the repo
  2. make a github release

The release PR also includes a space to add release notes, which are automatically extracted by the GHAs and used as the body of the published release.

The GHAs don't do an automated `cargo publish` for two reasons:
- those are irreversible; that's not so much a worry once established but until the GHAs work well it's preferable not to have any mistake require an extra bump and a yank
- the lack of scoped crates.io tokens makes it a safety issue

Also:
- Embeds a windows manifest to opt into some behaviours (segmented heap, long paths), declare a name and version number as part of windows metadata, and declare compatibility for windows 8 and up
- Improves compression for the archives. For linux debug builds that makes tars 80% smaller, though I doubt it will matter as much for release.