### PR TITLE
Fix: Create `temp_dir` in `install_path`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -250,7 +250,13 @@ async fn entry(jobserver_client: LazyJobserverClient) -> Result<()> {
     debug!("Using install path: {}", install_path.display());
 
     // Create a temporary directory for downloads etc.
-    let temp_dir = TempDir::new()
+    //
+    // Put all binaries to a temporary directory under `dst` first, catching
+    // some failure modes (e.g., out of space) before touching the existing
+    // binaries. This directory will get cleaned up via RAII.
+    let temp_dir = tempfile::Builder::new()
+        .prefix("cargo-binstall")
+        .tempdir_in(&install_path)
         .map_err(BinstallError::from)
         .wrap_err("Creating a temporary directory failed.")?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,6 @@ use clap::Parser;
 use log::{debug, error, info, warn, LevelFilter};
 use miette::{miette, Result, WrapErr};
 use simplelog::{ColorChoice, ConfigBuilder, TermLogger, TerminalMode};
-use tempfile::TempDir;
 use tokio::{runtime::Runtime, task::block_in_place};
 
 use cargo_binstall::{binstall, *};


### PR DESCRIPTION
Put all binaries to a temporary directory under `dst` first, catching
some failure modes (e.g., out of space) before touching the existing
binaries. This directory will get cleaned up via RAII. 

Shamelessly copied from https://github.com/rust-lang/cargo/blob/caf3c37d90081a211a2457f8b5543ae4cddb0142/src/cargo/ops/cargo_install.rs#L384

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>