### PR TITLE
Speedup ci by using liblzma-dev, libzip and libzstd provided by `apt`

### DIFF
--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -23,7 +23,7 @@ jobs:
             output: cargo-binstall
             use-cross: false
             test: true
-            debug_build_args: --no-default-features --features pkg-config
+            debug_build_args: --no-default-features --features rustls,pkg-config
           - target: x86_64-apple-darwin
             os: macos-latest
             output: cargo-binstall

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -35,7 +35,7 @@ jobs:
             output: cargo-binstall
             use-cross: false
             test: false
-            debug_build_args: --no-default-features --features native-tls
+            debug_build_args: --no-default-features --features rustls
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             output: cargo-binstall.exe

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -42,6 +42,7 @@ jobs:
             use-cross: false
             test: false
             debug_build_args: --no-default-features --features native-tls
+            release_build_args: --no-default-features --features static,zlib-ng,native-tls
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             output: cargo-binstall
@@ -92,7 +93,7 @@ jobs:
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       with:
         command: build
-        args: --target ${{ matrix.target }} --release
+        args: --target ${{ matrix.target }} --release ${{ matrix.release_build_args }}
         use-cross: ${{ matrix.use-cross }}
 
     - name: Build debug

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -23,13 +23,12 @@ jobs:
             output: cargo-binstall
             use-cross: false
             test: true
-            debug_build_args: --features pkg-config,native-tls
+            debug_build_args: --features pkg-config
           - target: x86_64-apple-darwin
             os: macos-latest
             output: cargo-binstall
             use-cross: false
             test: true
-            debug_build_args: --features native-tls
           - target: aarch64-apple-darwin
             os: macos-latest
             output: cargo-binstall

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -93,14 +93,14 @@ jobs:
 
     - name: Build debug
       uses: actions-rs/cargo@v1
-      if: ${{ ! startsWith(github.ref, 'refs/tags/v') && use-cross == 'false' }}
+      if: ${{ ! startsWith(github.ref, 'refs/tags/v') && matrix.use-cross == 'false' }}
       with:
         command: build
         args: --target ${{ matrix.target }} --no-default-features --features pkg-config,native-tls
 
     - name: Build debug with cross compilation
       uses: actions-rs/cargo@v1
-      if: ${{ ! startsWith(github.ref, 'refs/tags/v') && use-cross == 'true' }}
+      if: ${{ ! startsWith(github.ref, 'refs/tags/v') && matrix.use-cross == 'true' }}
       with:
         command: build
         args: --target ${{ matrix.target }} --no-default-features --features rustls

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -93,14 +93,14 @@ jobs:
 
     - name: Build debug
       uses: actions-rs/cargo@v1
-      if: ${{ ! startsWith(github.ref, 'refs/tags/v') && matrix.use-cross == 'false' }}
+      if: ${{ ! startsWith(github.ref, 'refs/tags/v') && matrix.use-cross }}
       with:
         command: build
         args: --target ${{ matrix.target }} --no-default-features --features pkg-config,native-tls
 
     - name: Build debug with cross compilation
       uses: actions-rs/cargo@v1
-      if: ${{ ! startsWith(github.ref, 'refs/tags/v') && matrix.use-cross == 'true' }}
+      if: ${{ ! startsWith(github.ref, 'refs/tags/v') && matrix.use-cross }}
       with:
         command: build
         args: --target ${{ matrix.target }} --no-default-features --features rustls

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -84,7 +84,7 @@ jobs:
       run: sudo apt-get install -y musl-tools
 
     - name: Install deps
-      if: ${{ startsWith(matrix.target, 'x86_64-unknown-linux-') && !startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' && !startsWith(github.ref, 'refs/tags/v') }}
       run: sudo ./ci-scripts/install-deps.sh
 
     - name: Build release

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -79,11 +79,9 @@ jobs:
       if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
       run: sudo apt-get install -y musl-tools
 
-    - name: Install liblzma-dev, libzip-dev and libzstd-dev
+    - name: Install deps
       if: ${{ startsWith(matrix.target, 'x86_64-unknown-linux-') && !startsWith(github.ref, 'refs/tags/v') }}
-      run: |
-        sudo apt update
-        sudo apt install -y --no-install-recommends liblzma-dev libzip-dev libzstd-dev
+      run: sudo ./ci-scripts/install-deps.sh
 
     - name: Build release
       uses: actions-rs/cargo@v1

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -48,18 +48,21 @@ jobs:
             output: cargo-binstall
             use-cross: false
             test: true
+            debug_build_args: --no-default-features --features rustls
           - target: armv7-unknown-linux-musleabihf
             os: ubuntu-20.04
             output: cargo-binstall
             use-cross: true
             test: false
+            debug_build_args: --no-default-features --features rustls
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             output: cargo-binstall
             use-cross: true
             test: false
-    runs-on: ${{ matrix.os }}
+            debug_build_args: --no-default-features --features rustls
 
+    runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
     - uses: FranzDiebold/github-env-vars-action@v1.2.1

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -98,7 +98,7 @@ jobs:
       if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
       with:
         command: build
-        args: --target ${{ matrix.target }}
+        args: --target ${{ matrix.target }} --no-default-features --features pkg-config
         use-cross: ${{ matrix.use-cross }}
 
     - name: Copy and rename utility

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -29,6 +29,7 @@ jobs:
             output: cargo-binstall
             use-cross: false
             test: true
+            debug_build_args: --no-default-features --features rustls
           - target: aarch64-apple-darwin
             os: macos-latest
             output: cargo-binstall

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -100,6 +100,7 @@ jobs:
       with:
         command: build
         args: --target ${{ matrix.target }} ${{ matrix.debug_build_args }}
+        use-cross: ${{ matrix.use-cross }}
 
     - name: Copy and rename utility
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -23,7 +23,7 @@ jobs:
             output: cargo-binstall
             use-cross: false
             test: true
-            debug_build_args: --features pkg-config
+            debug_build_args: --no-default-features --features pkg-config
           - target: x86_64-apple-darwin
             os: macos-latest
             output: cargo-binstall
@@ -34,13 +34,13 @@ jobs:
             output: cargo-binstall
             use-cross: false
             test: false
-            debug_build_args: --features native-tls
+            debug_build_args: --no-default-features --features native-tls
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             output: cargo-binstall.exe
             use-cross: false
             test: false
-            debug_build_args: --features native-tls
+            debug_build_args: --no-default-features --features native-tls
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             output: cargo-binstall
@@ -99,7 +99,7 @@ jobs:
       if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
       with:
         command: build
-        args: --target ${{ matrix.target }} --no-default-features ${{ matrix.debug_build_args }}
+        args: --target ${{ matrix.target }} ${{ matrix.debug_build_args }}
 
     - name: Copy and rename utility
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -91,20 +91,13 @@ jobs:
         args: --target ${{ matrix.target }} --release
         use-cross: ${{ matrix.use-cross }}
 
-    - name: Build debug with cross compilation
-      uses: actions-rs/cargo@v1
-      if: ${{ ! startsWith(github.ref, 'refs/tags/v') && matrix.use-cross == 'true' }}
-      with:
-        command: build
-        args: --target ${{ matrix.target }} --no-default-features
-        use-cross: true
-
     - name: Build debug
       uses: actions-rs/cargo@v1
       if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
       with:
         command: build
-        args: --target ${{ matrix.target }} --no-default-features --features pkg-config
+        args: --target ${{ matrix.target }} --no-default-features
+        use-cross: ${{ matrix.use-cross }}
 
     - name: Copy and rename utility
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -79,6 +79,12 @@ jobs:
       if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
       run: sudo apt-get install -y musl-tools
 
+    - name: Install liblzma-dev, libzip-dev and libzstd-dev
+      if: ${{ startsWith(matrix.target, 'x86_64-unknown-linux-') }}
+      run: |
+        sudo apt update
+        sudo apt install -y --no-install-recommends liblzma-dev libzip-dev libzstd-dev
+
     - name: Build release
       uses: actions-rs/cargo@v1
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -23,21 +23,25 @@ jobs:
             output: cargo-binstall
             use-cross: false
             test: true
+            debug_build_args: --features pkg-config,native-tls
           - target: x86_64-apple-darwin
             os: macos-latest
             output: cargo-binstall
             use-cross: false
             test: true
+            debug_build_args: --features native-tls
           - target: aarch64-apple-darwin
             os: macos-latest
             output: cargo-binstall
             use-cross: false
             test: false
+            debug_build_args: --features native-tls
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             output: cargo-binstall.exe
             use-cross: false
             test: false
+            debug_build_args: --features native-tls
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             output: cargo-binstall
@@ -93,18 +97,10 @@ jobs:
 
     - name: Build debug
       uses: actions-rs/cargo@v1
-      if: ${{ ! startsWith(github.ref, 'refs/tags/v') && matrix.use-cross }}
+      if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
       with:
         command: build
-        args: --target ${{ matrix.target }} --no-default-features --features pkg-config,native-tls
-
-    - name: Build debug with cross compilation
-      uses: actions-rs/cargo@v1
-      if: ${{ ! startsWith(github.ref, 'refs/tags/v') && matrix.use-cross }}
-      with:
-        command: build
-        args: --target ${{ matrix.target }} --no-default-features --features rustls
-        use-cross: true
+        args: --target ${{ matrix.target }} --no-default-features ${{ matrix.debug_build_args }}
 
     - name: Copy and rename utility
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -91,13 +91,20 @@ jobs:
         args: --target ${{ matrix.target }} --release
         use-cross: ${{ matrix.use-cross }}
 
+    - name: Build debug with cross compilation
+      uses: actions-rs/cargo@v1
+      if: ${{ ! startsWith(github.ref, 'refs/tags/v') && matrix.use-cross == 'true' }}
+      with:
+        command: build
+        args: --target ${{ matrix.target }} --no-default-features
+        use-cross: true
+
     - name: Build debug
       uses: actions-rs/cargo@v1
       if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
       with:
         command: build
         args: --target ${{ matrix.target }} --no-default-features --features pkg-config
-        use-cross: ${{ matrix.use-cross }}
 
     - name: Copy and rename utility
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -96,7 +96,7 @@ jobs:
       if: ${{ ! startsWith(github.ref, 'refs/tags/v') && use-cross == 'false' }}
       with:
         command: build
-        args: --target ${{ matrix.target }} --no-default-features --features native-tls
+        args: --target ${{ matrix.target }} --no-default-features --features pkg-config,native-tls
 
     - name: Build debug with cross compilation
       uses: actions-rs/cargo@v1

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -93,11 +93,18 @@ jobs:
 
     - name: Build debug
       uses: actions-rs/cargo@v1
-      if: ${{ ! startsWith(github.ref, 'refs/tags/v') }}
+      if: ${{ ! startsWith(github.ref, 'refs/tags/v') && use-cross == 'false' }}
       with:
         command: build
-        args: --target ${{ matrix.target }} --no-default-features
-        use-cross: ${{ matrix.use-cross }}
+        args: --target ${{ matrix.target }} --no-default-features --features native-tls
+
+    - name: Build debug with cross compilation
+      uses: actions-rs/cargo@v1
+      if: ${{ ! startsWith(github.ref, 'refs/tags/v') && use-cross == 'true' }}
+      with:
+        command: build
+        args: --target ${{ matrix.target }} --no-default-features --features rustls
+        use-cross: true
 
     - name: Copy and rename utility
       if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -80,7 +80,7 @@ jobs:
       run: sudo apt-get install -y musl-tools
 
     - name: Install liblzma-dev, libzip-dev and libzstd-dev
-      if: ${{ startsWith(matrix.target, 'x86_64-unknown-linux-') }}
+      if: ${{ startsWith(matrix.target, 'x86_64-unknown-linux-') && !startsWith(github.ref, 'refs/tags/v') }}
       run: |
         sudo apt update
         sudo apt install -y --no-install-recommends liblzma-dev libzip-dev libzstd-dev

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,6 +26,10 @@ jobs:
           path: |
             ${{ env.HOME }}/.cargo
             target
+      - name: Insall dependencies
+        run: |
+          apt update
+          apt install -y --no-install-recommends liblzma-dev libzip-dev libzstd-dev
       - name: test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,3 +30,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --no-default-features --features pkg-config

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,10 +26,8 @@ jobs:
           path: |
             ${{ env.HOME }}/.cargo
             target
-      - name: Install liblzma-dev, libzip-dev and libzstd-dev
-        run: |
-          sudo apt update
-          sudo apt install -y --no-install-recommends liblzma-dev libzip-dev libzstd-dev
+      - name: Install deps 
+        run: sudo ./ci-scripts/install-deps.sh
       - name: test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -32,4 +32,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --no-default-features --features pkg-config
+          args: --no-default-features --features pkg-config,native-tls

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,10 +26,10 @@ jobs:
           path: |
             ${{ env.HOME }}/.cargo
             target
-      - name: Insall dependencies
+      - name: Install liblzma-dev, libzip-dev and libzstd-dev
         run: |
-          apt update
-          apt install -y --no-install-recommends liblzma-dev libzip-dev libzstd-dev
+          sudo apt update
+          sudo apt install -y --no-install-recommends liblzma-dev libzip-dev libzstd-dev
       - name: test
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,4 +1789,5 @@ checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
 name = "crates_io_api"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -359,6 +375,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -620,6 +651,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,6 +871,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +931,51 @@ name = "once_cell"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
+name = "openssl"
+version = "0.10.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -1010,11 +1117,13 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -1023,6 +1132,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower-service",
@@ -1097,6 +1207,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,6 +1230,29 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1411,6 +1554,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1682,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,10 +70,14 @@ guess_host_triple = "0.1.3"
 
 [features]
 default = ["static", "zlib-ng", "rustls"]
+
 mimalloc = ["dep:mimalloc"]
+
 static = ["bzip2/static", "xz2/static"]
 pkg-config = ["zstd/pkg-config"]
+
 zlib-ng = ["flate2/zlib-ng"]
+
 rustls = ["crates_io_api/rustls", "reqwest/rustls-tls"]
 native-tls = ["reqwest/native-tls"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ guess_host_triple = "0.1.3"
 default = ["static"]
 mimalloc = ["dep:mimalloc"]
 static = ["bzip2/static", "xz2/static"]
+pkg-config = ["zstd/pkg-config"]
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ pkg-fmt = "zip"
 [dependencies]
 async-trait = "0.1.56"
 bytes = "1.1.0"
-bzip2 = { version = "0.4.3", features = ["static"] }
+bzip2 = "0.4.3"
 cargo_toml = "0.11.4"
 clap = { version = "3.2.12", features = ["derive"] }
 crates_io_api = { version = "0.8.0", default-features = false, features = ["rustls"] }
@@ -50,7 +50,7 @@ tinytemplate = "1.2.1"
 tokio = { version = "1.20.0", features = ["rt-multi-thread", "process", "sync"], default-features = false }
 toml = "0.5.9"
 url = "2.2.2"
-xz2 = { version = "0.1.6", features = ["static"] }
+xz2 = "0.1.6"
 
 # Disable all features of zip except for features of compression algorithms:
 # Disabled features include:
@@ -69,8 +69,9 @@ zstd = { version = "0.10.0", default-features = false }
 guess_host_triple = "0.1.3"
 
 [features]
-default = []
+default = ["static"]
 mimalloc = ["dep:mimalloc"]
+static = ["bzip2/static", "xz2/static"]
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ bytes = "1.1.0"
 bzip2 = "0.4.3"
 cargo_toml = "0.11.4"
 clap = { version = "3.2.12", features = ["derive"] }
-crates_io_api = { version = "0.8.0", default-features = false, features = ["rustls"] }
+crates_io_api = { version = "0.8.0", default-features = false }
 dirs = "4.0.0"
 flate2 = { version = "1.0.24", default-features = false }
 fs4 = "0.6.2"
@@ -35,7 +35,7 @@ log = "0.4.14"
 miette = { version = "5.1.1", features = ["fancy-no-backtrace"] }
 mimalloc = { version = "0.1.29", default-features = false, optional = true }
 once_cell = "1.13.0"
-reqwest = { version = "0.11.11", features = ["rustls-tls", "stream"], default-features = false }
+reqwest = { version = "0.11.11", features = ["stream"], default-features = false }
 scopeguard = "1.1.0"
 semver = "1.0.12"
 serde = { version = "1.0.139", features = ["derive"] }
@@ -69,11 +69,12 @@ zstd = { version = "0.10.0", default-features = false }
 guess_host_triple = "0.1.3"
 
 [features]
-default = ["static", "zlib-ng"]
+default = ["static", "zlib-ng", "rustls"]
 mimalloc = ["dep:mimalloc"]
 static = ["bzip2/static", "xz2/static"]
 pkg-config = ["zstd/pkg-config"]
 zlib-ng = ["flate2/zlib-ng"]
+rustls = ["crates_io_api/rustls", "reqwest/rustls-tls"]
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ cargo_toml = "0.11.4"
 clap = { version = "3.2.12", features = ["derive"] }
 crates_io_api = { version = "0.8.0", default-features = false, features = ["rustls"] }
 dirs = "4.0.0"
-flate2 = { version = "1.0.24", features = ["zlib-ng"], default-features = false }
+flate2 = { version = "1.0.24", default-features = false }
 fs4 = "0.6.2"
 futures-util = { version = "0.3.21", default-features = false }
 home = "0.5.3"
@@ -69,10 +69,11 @@ zstd = { version = "0.10.0", default-features = false }
 guess_host_triple = "0.1.3"
 
 [features]
-default = ["static"]
+default = ["static", "zlib-ng"]
 mimalloc = ["dep:mimalloc"]
 static = ["bzip2/static", "xz2/static"]
 pkg-config = ["zstd/pkg-config"]
+zlib-ng = ["flate2/zlib-ng"]
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ static = ["bzip2/static", "xz2/static"]
 pkg-config = ["zstd/pkg-config"]
 zlib-ng = ["flate2/zlib-ng"]
 rustls = ["crates_io_api/rustls", "reqwest/rustls-tls"]
+native-tls = ["reqwest/native-tls"]
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,11 +1,11 @@
 [target.armv7-unknown-linux-gnueabihf]
-image = "ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf@sha256:379eee7aa254912a803b558fe0742450dd32ca9749bc8b931927dafa2ce6e8d3"
+zig = true
 
 [target.armv7-unknown-linux-musleabihf]
-image = "ghcr.io/cross-rs/armv7-unknown-linux-musleabihf@sha256:00088ebbb98f5d9895c2b6e7f713cd3028331185fe82f60d93efc03bdff8ea65"
+zig = true
 
 [target.aarch64-unknown-linux-gnu]
-image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu@sha256:5db2a92c73d1251c5fb9de895928ef2551c08d0ec30b969cf7340ca3dd62ea81"
+zig = true
 
 [target.aarch64-unknown-linux-musl]
-image = "ghcr.io/cross-rs/aarch64-unknown-linux-musl@sha256:341256c185132fff9265ee7c8d94ba9b4fde3e8cfa8b39047c0e64ba4c1faf9a"
+zig = true

--- a/ci-scripts/install-deps.sh
+++ b/ci-scripts/install-deps.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+apt update
+exec apt install -y --no-install-recommends liblzma-dev libzip-dev libzstd-dev


### PR DESCRIPTION
Quite some time is spent compiling these images, so I create new features that allow system-wide libraries of these versions to be used.

However, I don't know how to install them inside the `cross` image, so they would still build these libraries and link with them statically.

This PR also disables building `zlib-ng` and uses native-tls on windows.

Edit:

This PR enables `zig-cc` for cross building.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>