### PR TITLE
Try to reenable armv7, aarch64 gnu targets

### DIFF
--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -67,6 +67,12 @@ jobs:
             use-cross: true
             test: false
             debug_build_args: --no-default-features --features rustls
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            output: cargo-binstall
+            use-cross: true
+            test: false
+            debug_build_args: --no-default-features --features rustls
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build-and-integration-tests.yml
+++ b/.github/workflows/build-and-integration-tests.yml
@@ -55,6 +55,12 @@ jobs:
             use-cross: true
             test: false
             debug_build_args: --no-default-features --features rustls
+          - target: armv7-unknown-linux-gnueabihf
+            os: ubuntu-20.04
+            output: cargo-binstall
+            use-cross: true
+            test: false
+            debug_build_args: --no-default-features --features rustls
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             output: cargo-binstall

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,11 +1,2 @@
-[target.armv7-unknown-linux-gnueabihf]
-zig = true
-
-[target.armv7-unknown-linux-musleabihf]
-zig = true
-
-[target.aarch64-unknown-linux-gnu]
-zig = true
-
-[target.aarch64-unknown-linux-musl]
+[build]
 zig = true


### PR DESCRIPTION
It has been a long time and the bugs on these targets might already be fixed by `cross`.

If not, then we can simply wait for release of 0.3.0, which adds support for `zig-cc` that can cross-compile any C/C++ code easily for any supported target.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>