### PR TITLE
Replace toml with toml_edit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ dependencies = [
  "thiserror",
  "tinytemplate",
  "tokio",
- "toml",
+ "toml_edit",
  "url",
  "xz2",
  "zip",
@@ -225,6 +225,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +305,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "either"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
 name = "embed-resource"
@@ -724,6 +740,15 @@ name = "is_ci"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
+name = "itertools"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1620,6 +1645,18 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5376256e44f2443f8896ac012507c19a012df0fe8758b55246ae51a2279db51f"
+dependencies = [
+ "combine",
+ "indexmap",
+ "itertools",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ tempfile = "3.3.0"
 thiserror = "1.0.31"
 tinytemplate = "1.2.1"
 tokio = { version = "1.20.0", features = ["rt-multi-thread", "process", "sync"], default-features = false }
-toml = "0.5.8"
+toml_edit = { version = "0.14.4", features = ["easy"] }
 url = "2.2.2"
 xz2 = "0.1.7"
 


### PR DESCRIPTION
The toml crate is unmaintained / not actively maintained, and may be replaced with toml_edit::easy anyway:
https://github.com/alexcrichton/toml-rs/issues/460#issuecomment-1163202480

Doesn't significantly affect overall build time:

```
$ hyperfine -p 'git s main; cargo clean' -p 'git s toml-edit; cargo clean' 'cargo build # toml' 'cargo build # toml-edit'
Benchmark 1: cargo build # toml
  Time (mean ± σ):     34.329 s ±  3.220 s    [User: 225.791 s, System: 19.169 s]
  Range (min … max):   32.100 s … 43.068 s    10 runs

Benchmark 2: cargo build # toml-edit
  Time (mean ± σ):     34.315 s ±  1.331 s    [User: 225.706 s, System: 19.183 s]
  Range (min … max):   32.607 s … 36.400 s    10 runs

Summary
  'cargo build # toml-edit' ran
    1.00 ± 0.10 times faster than 'cargo build # toml'
```