### PR TITLE
Fix the instructions for publish on the release PR

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -63,7 +63,7 @@ jobs:
 
           title="release: v${{ inputs.version }}"
           body_intro="This is a release PR for version **${{ inputs.version }}**."
-          body_merge="**Use squash merge.** Upon merging, this will automatically build the CLI and create a GitHub release. You still need to manually publish the cargo crate."
+          body_merge="**Use squash merge.**${nl}Upon merging, this will automatically build the CLI and create a GitHub release. You still need to manually publish the cargo crate."
           body_pub="${fence}$ git switch main${nl}$ git pull${nl}$ git checkout v${{ inputs.version }}${nl}$ cargo publish${ecnef}"
           body_notes="---${br}_Edit release notes into the section below:_${br}<!-- do not change or remove this heading -->${nl}### Release notes"
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -64,7 +64,7 @@ jobs:
           title="release: v${{ inputs.version }}"
           body_intro="This is a release PR for version **${{ inputs.version }}**."
           body_merge="**Use squash merge.** Upon merging, this will automatically build the CLI and create a GitHub release. You still need to manually publish the cargo crate."
-          body_pub="${fence}$ cd ${{ env.crate_path }}${nl}$ cargo publish${ecnef}"
+          body_pub="${fence}$ git switch main${nl}$ git pull${nl}$ git checkout v${{ inputs.version }}${nl}$ cargo publish${ecnef}"
           body_notes="---${br}_Edit release notes into the section below:_${br}<!-- do not change or remove this heading -->${nl}### Release notes"
 
           body="${body_intro}${br}${body_merge}${br}${body_pub}${br}${body_notes}${br}"


### PR DESCRIPTION
Minor cosmetic change, really. From this:

This is a release PR for version **0.11.0**.

**Use squash merge.** Upon merging, this will automatically build the CLI and create a GitHub release. You still need to manually publish the cargo crate.

```
$ cd 
$ cargo publish
```

---

To this:

This is a release PR for version **0.11.0**.

**Use squash merge.**
Upon merging, this will automatically build the CLI and create a GitHub release. You still need to manually publish the cargo crate.

```
$ git switch main
$ git pull
$ git checkout v0.11.0
$ cargo publish
```