### PR TITLE
Disable zig for now

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,2 +1,0 @@
-[build]
-zig = true


### PR DESCRIPTION
As it is not actually supported yet by the cross version in CI, this is precautionary such that the build does not magically start failing. We can re-enable it later.