### PR TITLE
Optimze updating `CratesToml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "castaway",
  "itoa",
  "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,7 @@ dependencies = [
  "bzip2",
  "cargo_toml",
  "clap",
+ "compact_str",
  "crates_io_api",
  "dirs",
  "embed-resource",
@@ -171,6 +172,15 @@ dependencies = [
  "serde",
  "serde_derive",
  "toml",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -255,6 +265,17 @@ checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5857fc4f27cd0fa2cd7c4a4fa780c0da3d898ae27e66bf6a719343e219e9a559"
+dependencies = [
+ "castaway",
+ "itoa",
+ "ryu",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ bytes = "1.2.0"
 bzip2 = "0.4.3"
 cargo_toml = "0.11.5"
 clap = { version = "3.2.14", features = ["derive"] }
-compact_str = "0.5.2"
+compact_str = { version = "0.5.2", features = ["serde"] }
 crates_io_api = { version = "0.8.0", default-features = false }
 dirs = "4.0.0"
 flate2 = { version = "1.0.24", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bytes = "1.2.0"
 bzip2 = "0.4.3"
 cargo_toml = "0.11.5"
 clap = { version = "3.2.14", features = ["derive"] }
+compact_str = "0.5.2"
 crates_io_api = { version = "0.8.0", default-features = false }
 dirs = "4.0.0"
 flate2 = { version = "1.0.24", default-features = false }

--- a/src/bins.rs
+++ b/src/bins.rs
@@ -1,13 +1,14 @@
 use std::path::{Path, PathBuf};
 
 use cargo_toml::Product;
+use compact_str::CompactString;
 use log::debug;
 use serde::Serialize;
 
 use crate::{atomic_install, atomic_symlink_file, BinstallError, PkgFmt, PkgMeta, Template};
 
 pub struct BinFile {
-    pub base_name: String,
+    pub base_name: CompactString,
     pub source: PathBuf,
     pub dest: PathBuf,
     pub link: PathBuf,
@@ -15,7 +16,7 @@ pub struct BinFile {
 
 impl BinFile {
     pub fn from_product(data: &Data, product: &Product) -> Result<Self, BinstallError> {
-        let base_name = product.name.clone().unwrap();
+        let base_name = CompactString::from(product.name.clone().unwrap());
 
         let binary_ext = if data.target.contains("windows") {
             ".exe"

--- a/src/binstall.rs
+++ b/src/binstall.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use crate::{metafiles, DesiredTargets, PkgOverride};
@@ -20,7 +19,7 @@ pub struct Options {
 
 /// MetaData required to update MetaFiles.
 pub struct MetaData {
-    pub bins: BTreeSet<String>,
+    pub bins: Vec<String>,
     pub cvs: metafiles::CrateVersionSource,
     pub version_req: String,
     pub target: String,

--- a/src/binstall.rs
+++ b/src/binstall.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use compact_str::CompactString;
+
 use crate::{metafiles, DesiredTargets, PkgOverride};
 
 mod resolve;
@@ -19,7 +21,7 @@ pub struct Options {
 
 /// MetaData required to update MetaFiles.
 pub struct MetaData {
-    pub bins: Vec<String>,
+    pub bins: Vec<CompactString>,
     pub cvs: metafiles::CrateVersionSource,
     pub version_req: String,
     pub target: String,

--- a/src/metafiles/v1.rs
+++ b/src/metafiles/v1.rs
@@ -6,6 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use compact_str::CompactString;
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -15,7 +16,7 @@ use crate::{cargo_home, create_if_not_exist, FileLock};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct CratesToml {
-    v1: BTreeMap<String, Vec<String>>,
+    v1: BTreeMap<String, Vec<CompactString>>,
 }
 
 impl CratesToml {
@@ -38,7 +39,7 @@ impl CratesToml {
         Self::load_from_reader(file)
     }
 
-    pub fn insert(&mut self, cvs: &CrateVersionSource, bins: Vec<String>) {
+    pub fn insert(&mut self, cvs: &CrateVersionSource, bins: Vec<CompactString>) {
         self.v1.insert(cvs.to_string(), bins);
     }
 
@@ -70,7 +71,7 @@ impl CratesToml {
         iter: Iter,
     ) -> Result<(), CratesTomlParseError>
     where
-        Iter: IntoIterator<Item = (&'a CrateVersionSource, Vec<String>)>,
+        Iter: IntoIterator<Item = (&'a CrateVersionSource, Vec<CompactString>)>,
     {
         let mut file = FileLock::new_exclusive(create_if_not_exist(path.as_ref())?)?;
         let mut c1 = Self::load_from_reader(&mut *file)?;
@@ -87,7 +88,7 @@ impl CratesToml {
 
     pub fn append<'a, Iter>(iter: Iter) -> Result<(), CratesTomlParseError>
     where
-        Iter: IntoIterator<Item = (&'a CrateVersionSource, Vec<String>)>,
+        Iter: IntoIterator<Item = (&'a CrateVersionSource, Vec<CompactString>)>,
     {
         Self::append_to_path(Self::default_path()?, iter)
     }

--- a/src/metafiles/v1.rs
+++ b/src/metafiles/v1.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeMap,
     fs::File,
     io::{self, Seek},
     iter::IntoIterator,
@@ -15,7 +15,7 @@ use crate::{cargo_home, create_if_not_exist, FileLock};
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct CratesToml {
-    v1: BTreeMap<String, BTreeSet<String>>,
+    v1: BTreeMap<String, Vec<String>>,
 }
 
 impl CratesToml {
@@ -38,7 +38,7 @@ impl CratesToml {
         Self::load_from_reader(file)
     }
 
-    pub fn insert(&mut self, cvs: &CrateVersionSource, bins: BTreeSet<String>) {
+    pub fn insert(&mut self, cvs: &CrateVersionSource, bins: Vec<String>) {
         self.v1.insert(cvs.to_string(), bins);
     }
 
@@ -70,7 +70,7 @@ impl CratesToml {
         iter: Iter,
     ) -> Result<(), CratesTomlParseError>
     where
-        Iter: IntoIterator<Item = (&'a CrateVersionSource, BTreeSet<String>)>,
+        Iter: IntoIterator<Item = (&'a CrateVersionSource, Vec<String>)>,
     {
         let mut file = FileLock::new_exclusive(create_if_not_exist(path.as_ref())?)?;
         let mut c1 = Self::load_from_reader(&mut *file)?;
@@ -87,7 +87,7 @@ impl CratesToml {
 
     pub fn append<'a, Iter>(iter: Iter) -> Result<(), CratesTomlParseError>
     where
-        Iter: IntoIterator<Item = (&'a CrateVersionSource, BTreeSet<String>)>,
+        Iter: IntoIterator<Item = (&'a CrateVersionSource, Vec<String>)>,
     {
         Self::append_to_path(Self::default_path()?, iter)
     }


### PR DESCRIPTION
 - Use `Vec` instead of `BTreeSet` to store bins since it is already unique
 - Use `CompactString` instead of `String` to store the name of bins since many of them are less than 24 bytes (`CompactString` can store up to 24 bytes inline on 64-bit platforms and 12 bytes on 32-bit platforms).

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>