### PR TITLE
Split features and build args handling in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,15 +28,15 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-            debug_build_args: --no-default-features --features rustls,pkg-config
+            debug_features: [ rustls, pkg-config ]
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc
             os: windows-latest
-            debug_build_args: --no-default-features --features native-tls
-            release_build_args: --no-default-features --features static,zlib-ng,native-tls,fancy-no-backtrace
+            debug_features: [ native-tls ]
+            release_features: [ static, zlib-ng, native-tls, fancy-no-backtrace ]
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
           - target: armv7-unknown-linux-musleabihf

--- a/ci-scripts/compile-settings.jq
+++ b/ci-scripts/compile-settings.jq
@@ -2,17 +2,25 @@ if $for_release then {
   output: "release",
   profile: "release",
   args: ($matrix.release_build_args // ""),
+  features: ($matrix.release_features // []),
 } else {
   output: "debug",
   profile: "dev",
-  args: ($matrix.debug_build_args // "--no-default-features --features rustls,fancy-with-backtrace"),
+  args: ($matrix.debug_build_args // ""),
+  features: ($matrix.debug_features // ["rustls", "fancy-with-backtrace"]),
 } end
+|
+.features = (
+  if (.features | length > 0)
+  then "--no-default-features --features \(.features | join(","))"
+  else "" end
+)
 |
 {
   CBIN: (if ($matrix.target | test("windows")) then "cargo-binstall.exe" else "cargo-binstall" end),
   CTOOL: (if ($matrix."use-cross" // false) then "cross" else "cargo" end),
   COUTPUT: .output,
-  CARGS: "--target \($matrix.target) --profile \(.profile) \(.args)",
+  CARGS: "--target \($matrix.target) --profile \(.profile) \(.features) \(.args)",
 }
 |
 to_entries[] | "\(.key)=\(.value)"


### PR DESCRIPTION
Support for #256: that way pure build args (e.g. `-Z` stuff) can be specified independently of the feature sets.