### PR TITLE
Fix miniwasi.wast correctness

### DIFF
--- a/src/miniwasi.wast
+++ b/src/miniwasi.wast
@@ -1,8 +1,8 @@
 (module
+ (import "wasi_snapshot_preview1" "proc_exit" (func $exit (param i32)))
  (memory $0 0)
  (export "memory" (memory $0))
  (export "_start" (func $0))
- (import "wasi_snapshot_preview1" "proc_exit" (func $exit (param i32)))
  (func $0
   (call $exit (i32.const 0))
   (unreachable)


### PR DESCRIPTION
As mentioned in #246, the imports must appear at the top; this wasn't checked by binaryen's tooling and doesn't change the output, but might as well have something strictly correct