### PR TITLE
Add -V, clean up errors and help text

### DIFF
--- a/src/binstall/resolve.rs
+++ b/src/binstall/resolve.rs
@@ -85,7 +85,7 @@ pub async fn resolve(
     let mut version = match (&crate_name.version, &opts.version) {
         (Some(version), None) => version.to_string(),
         (None, Some(version)) => version.to_string(),
-        (Some(_), Some(_)) => Err(BinstallError::DuplicateVersionReq)?,
+        (Some(_), Some(_)) => Err(BinstallError::SuperfluousVersionOption)?,
         (None, None) => "*".to_string(),
     };
 
@@ -103,7 +103,7 @@ pub async fn resolve(
     // TODO: work out which of these to do based on `opts.name`
     // TODO: support git-based fetches (whole repo name rather than just crate name)
     let manifest = match opts.manifest_path.clone() {
-        Some(manifest_path) => load_manifest_path(manifest_path.join("Cargo.toml"))?,
+        Some(manifest_path) => load_manifest_path(manifest_path)?,
         None => {
             fetch_crate_cratesio(&client, &crates_io_api_client, &crate_name.name, &version).await?
         }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -88,7 +88,17 @@ pub fn load_manifest_path<P: AsRef<Path>>(
     manifest_path: P,
 ) -> Result<Manifest<Meta>, BinstallError> {
     block_in_place(|| {
-        debug!("Reading manifest: {}", manifest_path.as_ref().display());
+        let manifest_path = manifest_path.as_ref();
+        let manifest_path = if manifest_path.is_dir() {
+            manifest_path.join("Cargo.toml")
+        } else {
+            manifest_path.into()
+        };
+
+        debug!(
+            "Reading manifest at local path: {}",
+            manifest_path.display()
+        );
 
         // Load and parse manifest (this checks file system for binary output names)
         let manifest = Manifest::<Meta>::from_path_with_metadata(manifest_path)?;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -91,8 +91,10 @@ pub fn load_manifest_path<P: AsRef<Path>>(
         let manifest_path = manifest_path.as_ref();
         let manifest_path = if manifest_path.is_dir() {
             manifest_path.join("Cargo.toml")
-        } else {
+        } else if manifest_path.is_file() {
             manifest_path.into()
+        } else {
+            return Err(BinstallError::CargoManifestPath);
         };
 
         debug!(


### PR DESCRIPTION
- Add `-V` to print version (#248)
- Clean up some errors' documentation and names
- Allow `--manifest-path` to take both a crate folder path and a `Cargo.toml`'s path
- Rewrite some option help texts
- Add some help sections to organise things and be able to refer to overrides as a group