### PR TITLE
Fix repeated crates on batch installation: Dedup them and only keep the last one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,7 @@ dependencies = [
  "futures-util",
  "guess_host_triple",
  "home",
+ "itertools",
  "jobserver",
  "log",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ flate2 = { version = "1.0.24", default-features = false }
 fs4 = "0.6.2"
 futures-util = { version = "0.3.21", default-features = false }
 home = "0.5.3"
+itertools = "0.10.3"
 jobserver = "0.1.24"
 log = "0.4.17"
 miette = "5.1.1"

--- a/src/binstall/resolve.rs
+++ b/src/binstall/resolve.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use cargo_toml::{Package, Product};
+use compact_str::CompactString;
 use log::{debug, error, info, warn};
 use miette::{miette, Result};
 use reqwest::Client;
@@ -19,7 +20,7 @@ pub enum Resolution {
     Fetch {
         fetcher: Arc<dyn Fetcher>,
         package: Package<Meta>,
-        name: String,
+        name: CompactString,
         version: String,
         bin_path: PathBuf,
         bin_files: Vec<bins::BinFile>,

--- a/src/helpers/crate_name.rs
+++ b/src/helpers/crate_name.rs
@@ -1,11 +1,12 @@
 use std::{convert::Infallible, fmt, str::FromStr};
 
+use compact_str::CompactString;
 use itertools::Itertools;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct CrateName {
-    pub name: String,
-    pub version: Option<String>,
+    pub name: CompactString,
+    pub version: Option<CompactString>,
 }
 
 impl fmt::Display for CrateName {
@@ -26,12 +27,12 @@ impl FromStr for CrateName {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(if let Some((name, version)) = s.split_once('@') {
             CrateName {
-                name: name.to_string(),
-                version: Some(version.to_string()),
+                name: name.into(),
+                version: Some(version.into()),
             }
         } else {
             CrateName {
-                name: s.to_string(),
+                name: s.into(),
                 version: None,
             }
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,7 +241,7 @@ async fn entry(jobserver_client: LazyJobserverClient) -> Result<()> {
             ""
         };
 
-        if option != "" {
+        if !option.is_empty() {
             return Err(BinstallError::OverrideOptionUsedWithMultiInstall { option }.into());
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,9 @@ struct Options {
     ///
     /// When multiple names are provided, the --version option and any override options are
     /// unavailable due to ambiguity.
+    ///
+    /// If duplicate names are provided, the last one (and their version requirement)
+    /// is kept.
     #[clap(help_heading = "Package selection", value_name = "crate[@version]")]
     crate_names: Vec<CrateName>,
 
@@ -245,6 +248,9 @@ async fn entry(jobserver_client: LazyJobserverClient) -> Result<()> {
             return Err(BinstallError::OverrideOptionUsedWithMultiInstall { option }.into());
         }
     }
+
+    // Remove duplicate crate_name, keep the last one
+    let crate_names = CrateName::dedup(crate_names);
 
     let cli_overrides = PkgOverride {
         pkg_url: opts.pkg_url.take(),


### PR DESCRIPTION
Also contains some minor optimization by using `CompactString` in place of `String`.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>