### PR TITLE
Minor fix (use `PathBuf` instead of `String` to relax utf-8 req) and micro optimization

### DIFF
--- a/src/binstall.rs
+++ b/src/binstall.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use compact_str::CompactString;
+
 use crate::{metafiles::binstall_v1::MetaData, DesiredTargets, PkgOverride};
 
 mod resolve;
@@ -11,7 +13,7 @@ pub use install::*;
 pub struct Options {
     pub no_symlinks: bool,
     pub dry_run: bool,
-    pub version: Option<String>,
+    pub version: Option<CompactString>,
     pub manifest_path: Option<PathBuf>,
     pub cli_overrides: PkgOverride,
     pub desired_targets: DesiredTargets,

--- a/src/fetchers.rs
+++ b/src/fetchers.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use compact_str::CompactString;
 pub use gh_crate_meta::*;
 pub use log::debug;
 pub use quickinstall::*;
@@ -35,7 +36,7 @@ pub trait Fetcher: Send + Sync {
     fn pkg_fmt(&self) -> PkgFmt;
 
     /// A short human-readable name or descriptor for the package source
-    fn source_name(&self) -> String;
+    fn source_name(&self) -> CompactString;
 
     /// Should return true if the remote is from a third-party source
     fn is_third_party(&self) -> bool;

--- a/src/fetchers/gh_crate_meta.rs
+++ b/src/fetchers/gh_crate_meta.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use compact_str::{CompactString, ToCompactString};
 use log::{debug, info, warn};
 use once_cell::sync::OnceCell;
 use reqwest::Client;
@@ -79,19 +80,19 @@ impl super::Fetcher for GhCrateMeta {
         self.data.meta.pkg_fmt
     }
 
-    fn source_name(&self) -> String {
+    fn source_name(&self) -> CompactString {
         self.url
             .get()
             .map(|url| {
                 if let Some(domain) = url.domain() {
-                    domain.to_string()
+                    domain.to_compact_string()
                 } else if let Some(host) = url.host_str() {
-                    host.to_string()
+                    host.to_compact_string()
                 } else {
-                    url.to_string()
+                    url.to_compact_string()
                 }
             })
-            .unwrap_or_else(|| "invalid url".to_string())
+            .unwrap_or_else(|| "invalid url".into())
     }
 
     fn is_third_party(&self) -> bool {

--- a/src/fetchers/quickinstall.rs
+++ b/src/fetchers/quickinstall.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use compact_str::CompactString;
 use log::{debug, info};
 use reqwest::Client;
 use reqwest::Method;
@@ -49,8 +50,8 @@ impl super::Fetcher for QuickInstall {
         PkgFmt::Tgz
     }
 
-    fn source_name(&self) -> String {
-        String::from("QuickInstall")
+    fn source_name(&self) -> CompactString {
+        CompactString::from("QuickInstall")
     }
 
     fn is_third_party(&self) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ struct Options {
     /// switches over to a "local" install, where binaries are installed at the path given, and the
     /// global metadata files are not updated.
     #[clap(help_heading = "Options", long)]
-    install_path: Option<String>,
+    install_path: Option<PathBuf>,
 
     /// Enforce downloads over secure transports only.
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use clap::{AppSettings, Parser};
+use compact_str::CompactString;
 use log::{debug, error, info, warn, LevelFilter};
 use miette::{miette, Result, WrapErr};
 use simplelog::{ColorChoice, ConfigBuilder, TermLogger, TerminalMode};
@@ -42,7 +43,7 @@ struct Options {
     /// Cannot be used when multiple packages are installed at once, use the attached version
     /// syntax in that case.
     #[clap(help_heading = "Package selection", long = "version")]
-    version_req: Option<String>,
+    version_req: Option<CompactString>,
 
     /// Override binary target set.
     ///


### PR DESCRIPTION
Use `CompactString` instead of `String` for strings that can be fit into 24b.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>